### PR TITLE
feat: use photo picker API instead of intent.action.PICK

### DIFF
--- a/minecraft/src/main/java/com/mojang/minecraftpe/MainActivity.java
+++ b/minecraft/src/main/java/com/mojang/minecraftpe/MainActivity.java
@@ -44,6 +44,10 @@ import androidx.core.content.FileProvider;
 import androidx.core.math.MathUtils;
 import androidx.core.splashscreen.SplashScreen;
 import androidx.preference.PreferenceManager;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.PickVisualMediaRequest;
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.activity.result.contract.ActivityResultContracts;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.androidgamesdk.GameActivity;
 import com.google.firebase.FirebaseApp;
@@ -150,6 +154,7 @@ public class MainActivity extends GameActivity implements View.OnKeyListener, Fi
     Debug.MemoryInfo mCachedDebugMemoryInfo = new Debug.MemoryInfo();
     long mCachedDebugMemoryUpdateTime = 0;
     private long mCallback = 0;
+    private ActivityResultLauncher<PickVisualMediaRequest> pickMedia;
 
     enum MessageConnectionStatus {
         NOTSET,
@@ -493,6 +498,24 @@ public class MainActivity extends GameActivity implements View.OnKeyListener, Fi
         });
 
         mWorldRecovery = new WorldRecovery(getApplicationContext(), getApplicationContext().getContentResolver());
+
+        pickMedia =
+                registerForActivityResult(new ActivityResultContracts.PickVisualMedia(), uri -> {
+                    if (uri != null) {
+                        String[] projection = {MediaStore.Images.Media.DATA};
+                        Cursor cursor = getContentResolver().query(uri, projection, null, null, null);
+                        if (cursor != null && cursor.moveToFirst()) {
+                            String filePath = cursor.getString(cursor.getColumnIndexOrThrow(projection[0]));
+                            nativeOnPickImageSuccess(mCallback, filePath);
+                            cursor.close();
+                        } else {
+                            nativeOnPickImageCanceled(mCallback);    
+                        }
+                    } else {
+                        nativeOnPickImageCanceled(mCallback);
+                    }
+                });
+
     }
 
 
@@ -1657,8 +1680,10 @@ public class MainActivity extends GameActivity implements View.OnKeyListener, Fi
     void pickImage(long callback) {
         mCallback = callback;
         try {
-            startActivityForResult(new Intent("android.intent.action.PICK", MediaStore.Images.Media.EXTERNAL_CONTENT_URI), RESULT_PICK_IMAGE);
-        } catch (ActivityNotFoundException e) {
+            pickMedia.launch(new PickVisualMediaRequest.Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
+                    .build());
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -1715,20 +1740,10 @@ public class MainActivity extends GameActivity implements View.OnKeyListener, Fi
                 if (requestCode == OPEN_FILE_RESULT_CODE || requestCode == SAVE_FILE_RESULT_CODE) {
                     mPickedFileDescriptor = getContentResolver().openFileDescriptor(data, requestCode == OPEN_FILE_RESULT_CODE ? "r" : "w");
                     onPickFileSuccess(requestCode == OPEN_FILE_RESULT_CODE);
-                } else if (requestCode == RESULT_PICK_IMAGE) {
-                    String[] projection = {MediaStore.Images.Media.DATA};
-                    Cursor cursor = getContentResolver().query(data, projection, null, null, null);
-                    if (cursor != null && cursor.moveToFirst()) {
-                        String filePath = cursor.getString(cursor.getColumnIndexOrThrow(projection[0]));
-                        nativeOnPickImageSuccess(mCallback, filePath);
-                        cursor.close();
-                    }
                 }
             } catch (IOException e) {
                 e.printStackTrace();
             }
-        } else if (requestCode == RESULT_PICK_IMAGE) {
-            nativeOnPickImageCanceled(mCallback);
         }
     }
 


### PR DESCRIPTION
* Will make local skin picking much easier
* Will use either Android's own photo picker UI or the backported one by Google, falls back to ACTION_OPEN_DOCUMENT if neither are available
* Using photo picker API means user will no longer have to switch to an entirely different app to pick skin on supported devices. The game remains open when using this API. So, user don't have to wait for game to reload

Possible issue: ACTION_OPEN document maybe different from ACTION_PICK. Which may lead to skin picker not work as expected on unsupported devices. (confirmation needed)

Context:
- https://developer.android.com/training/data-storage/shared/photo-picker

You can keep it pending until you're sure