### PR TITLE
i18n: standardize language labels across locales

### DIFF
--- a/app/src/main/java/org/levimc/launcher/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/org/levimc/launcher/ui/activities/SettingsActivity.java
@@ -210,32 +210,34 @@ public class SettingsActivity extends BaseActivity {
         LanguageManager languageManager = new LanguageManager(this);
         FeatureSettings fs = FeatureSettings.getInstance();
 
+        // Keep English at the top (default language).
+        // Sort all other languages alphabetically by their display name.
         String[] languageOptions = {
                 getString(R.string.english),
                 getString(R.string.chinese),
-                getString(R.string.russian),
-                getString(R.string.indonesian),
-                getString(R.string.spanish),
-                getString(R.string.portuguese),
                 getString(R.string.french),
-                getString(R.string.japanese),
                 getString(R.string.hindi),
-		        getString(R.string.turkish),
-			    getString(R.string.vietnamese)
+                getString(R.string.indonesian),
+                getString(R.string.japanese),
+                getString(R.string.portuguese),
+                getString(R.string.russian),
+                getString(R.string.spanish),
+                getString(R.string.turkish),
+                getString(R.string.vietnamese)
         };
 
         String currentCode = languageManager.getCurrentLanguage();
         int defaultIdx = switch (currentCode) {
             case "zh", "zh-CN" -> 1;
-            case "ru" -> 2;
-            case "idn" -> 3;
-            case "es" -> 4;
-            case "pt" -> 5;
-            case "fr" -> 6;
-            case "ja" -> 7;
-            case "hi" -> 8;
-	        case "tr", "tr-TR" -> 9;
-			case "vi" -> 10;
+            case "fr" -> 2;
+            case "hi" -> 3;
+            case "idn" -> 4;
+            case "ja" -> 5;
+            case "pt" -> 6;
+            case "ru" -> 7;
+            case "es" -> 8;
+            case "tr", "tr-TR" -> 9;
+            case "vi" -> 10;
             default -> 0;
         };
 
@@ -253,15 +255,15 @@ public class SettingsActivity extends BaseActivity {
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 String code = switch (position) {
                     case 1 -> "zh-CN";
-                    case 2 -> "ru";
-                    case 3 -> "idn";
-                    case 4 -> "es";
-                    case 5 -> "pt";
-                    case 6 -> "fr";
-                    case 7 -> "ja";
-                    case 8 -> "hi";
-		            case 9 -> "tr";
-					case 10 -> "vi";
+                    case 2 -> "fr";
+                    case 3 -> "hi";
+                    case 4 -> "idn";
+                    case 5 -> "ja";
+                    case 6 -> "pt";
+                    case 7 -> "ru";
+                    case 8 -> "es";
+                    case 9 -> "tr";
+                    case 10 -> "vi";
                     default -> "en";
                 };
                 if (!code.equals(languageManager.getCurrentLanguage())) {

--- a/app/src/main/java/org/levimc/launcher/util/LanguageManager.java
+++ b/app/src/main/java/org/levimc/launcher/util/LanguageManager.java
@@ -50,32 +50,35 @@ public class LanguageManager {
 
         popup.setOnMenuItemClickListener(item -> {
             int itemId = item.getItemId();
+
+            // Keep English at the top (default language).
+            // Sort all other languages alphabetically by their display name.
             if (itemId == R.id.action_english) {
                 setAppLanguage("en");
                 return true;
             } else if (itemId == R.id.action_chinese) {
                 setAppLanguage("zh-CN");
                 return true;
-            } else if (itemId == R.id.action_russian) {
-                setAppLanguage("ru");
+            } else if (itemId == R.id.action_french) {
+                setAppLanguage("fr");
+                return true;
+            } else if (itemId == R.id.action_hindi) {
+                setAppLanguage("hi");
                 return true;
             } else if (itemId == R.id.action_indonesian) {
                 setAppLanguage("idn");
                 return true;
-            } else if (itemId == R.id.action_spanish) {
-                setAppLanguage("es");
+            } else if (itemId == R.id.action_japanese) {
+                setAppLanguage("ja");
                 return true;
             } else if (itemId == R.id.action_portuguese) {
                 setAppLanguage("pt");
                 return true;
-            } else if (itemId == R.id.action_french) {
-                setAppLanguage("fr");
+            } else if (itemId == R.id.action_russian) {
+                setAppLanguage("ru");
                 return true;
-            } else if (itemId == R.id.action_japanese) {
-                setAppLanguage("ja");
-                return true;
-            } else if (itemId == R.id.action_hindi) {
-                setAppLanguage("hi");
+            } else if (itemId == R.id.action_spanish) {
+                setAppLanguage("es");
                 return true;
             } else if (itemId == R.id.action_turkish) {
                 setAppLanguage("tr");
@@ -84,7 +87,6 @@ public class LanguageManager {
                 setAppLanguage("vi");
                 return true;
             }
-            
             return false;
         });
 

--- a/app/src/main/res/menu/language_menu.xml
+++ b/app/src/main/res/menu/language_menu.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <item
         android:id="@+id/action_english"
         android:title="@string/english"/>
@@ -7,26 +9,26 @@
         android:id="@+id/action_chinese"
         android:title="@string/chinese"/>
     <item
-        android:id="@+id/action_russian"
-        android:title="@string/russian"/>
+        android:id="@+id/action_french"
+        android:title="@string/french"/>
+    <item
+        android:id="@+id/action_hindi"
+        android:title="@string/hindi"/>
     <item
         android:id="@+id/action_indonesian"
         android:title="@string/indonesian"/>
     <item
-        android:id="@+id/action_spanish"
-        android:title="@string/spanish"/>
+        android:id="@+id/action_japanese"
+        android:title="@string/japanese"/>
     <item
         android:id="@+id/action_portuguese"
         android:title="@string/portuguese"/>
     <item
-        android:id="@+id/action_french"
-        android:title="@string/french"/>
+        android:id="@+id/action_russian"
+        android:title="@string/russian"/>
     <item
-        android:id="@+id/action_japanese"
-        android:title="@string/japanese"/>
-    <item
-        android:id="@+id/action_hindi"
-        android:title="@string/hindi"/>
+        android:id="@+id/action_spanish"
+        android:title="@string/spanish"/>
     <item
         android:id="@+id/action_turkish"
         android:title="@string/turkish"/>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -268,17 +268,17 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="instance_batch_backup_failed_message">No se pudo crear ninguna copia:\n%1$s</string>
 
     <string name="language">Idioma (Language)</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="english">Inglés (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <string name="rename_version_title">Renombrar Versión</string>
     <string name="rename_version_message">Introduce un nuevo nombre para esta versión:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -268,17 +268,17 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="instance_batch_backup_failed_message">Impossible de créer une sauvegarde :\n%1$s</string>
 
     <string name="language">Langue (Language)</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="english">Anglais (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <string name="rename_version_title">Renommer la version</string>
     <string name="rename_version_message">Entrez un nouveau nom pour cette version :</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -268,18 +268,18 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="instance_batch_backup_failed_message">कोई बैकअप नहीं बनाया जा सका:\n%1$s</string>
 
     <!-- Language Setting -->
-    <string name="language">भाषा</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="language">भाषा (Language)</string>
+    <string name="english">अंग्रेज़ी (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Version Rename -->
     <string name="rename_version_title">संस्करण का नाम बदलें</string>

--- a/app/src/main/res/values-idn/strings.xml
+++ b/app/src/main/res/values-idn/strings.xml
@@ -219,18 +219,18 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="version_isolation">Isolasi Versi</string>
 
     <!-- Language Setting -->
-    <string name="language">Bahasa</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="language">Bahasa (Language)</string>
+    <string name="english">Inggris (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Version Rename -->
     <string name="rename_version_title">Ganti Nama Versi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -268,17 +268,17 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="instance_batch_backup_failed_message">バックアップを作成できませんでした:\n%1$s</string>
 
     <string name="language">言語 (Language)</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="english">英語 (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <string name="rename_version_title">バージョンの名前変更</string>
     <string name="rename_version_message">このバージョンの新しい名前を入力してください:</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -268,17 +268,17 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="instance_batch_backup_failed_message">Não foi possível criar nenhum backup:\n%1$s</string>
 
     <string name="language">Idioma (Language)</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="english">Inglés (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <string name="rename_version_title">Renomear Versão</string>
     <string name="rename_version_message">Insira um novo nome para esta versão:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -219,18 +219,18 @@
     <string name="version_isolation">Изоляция версий</string>
 
     <!-- Настройки языка -->
-    <string name="language">Язык</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="language">Язык (Language)</string>
+    <string name="english">Английский (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Переименовать версию -->
     <string name="rename_version_title">Переименовать версию</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -284,18 +284,18 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="instance_restore_failed_message">Yedek geri yüklenemedi:\n%1$s</string>
 
     <!-- Language Setting -->
-    <string name="language">Dil</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="language">Dil (Language)</string>
+    <string name="english">İngilizce (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Version Rename -->
     <string name="rename_version_title">Sürümü Yeniden Adlandır</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -270,18 +270,18 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="instance_restore_failed_message">Không thể khôi phục bản sao lưu:\n%1$s</string>
 
     <!-- Language Setting -->
-    <string name="language">Language</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="vietnamese">Tiếng Việt</string>
-
+    <string name="language">ngôn ngữ (Language)</string>
+    <string name="english">Tiếng Anh (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Version Rename -->
     <string name="rename_version_title">Đổi tên phiên bản</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -217,18 +217,18 @@
 
     <string name="version_isolation">版本隔离</string>
     <!-- Language Setting -->
-    <string name="language">语言</string>
-    <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="language">语言 (Language)</string>
+    <string name="english">英语 (English)</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- 版本重命名 -->
     <string name="rename_version_title">重命名版本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,18 +287,20 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="instance_restore_failed_message">Could not restore backup:\n%1$s</string>
 
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Language</string>
     <string name="english">English</string>
-    <string name="chinese">简体中文</string>
-    <string name="russian">Русский</string>
-    <string name="indonesian">Bahasa Indonesia</string>
-    <string name="spanish">Español</string>
-    <string name="portuguese">Português</string>
-    <string name="french">Français</string>
-    <string name="japanese">日本語</string>
-    <string name="hindi">हिन्दी</string>
-    <string name="turkish">Türkçe</string>
-    <string name="vietnamese">Tiếng Việt</string>
+    <string name="chinese">简体中文 (Chinese)</string>
+    <string name="french">Français (French)</string>
+    <string name="hindi">हिन्दी (Hindi)</string>
+    <string name="indonesian">Bahasa Indonesia (Indonesian)</string>
+    <string name="japanese">日本語 (Japanese)</string>
+    <string name="portuguese">Português (Portuguese)</string>
+    <string name="russian">Русский (Russian)</string>
+    <string name="spanish">Español (Spanish)</string>
+    <string name="turkish">Türkçe (Turkish)</string>
+    <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
     <!-- Version Rename -->
     <string name="rename_version_title">Rename Version</string>


### PR DESCRIPTION
## Summary

This PR cleans up language-related UI inconsistencies in LeviLaunchroid and improves the language selection experience.

### Closes Issues

Closes #291, #328, #329

> [!IMPORTANT]
> This change focuses on consistency, readability, and recovery. It does not change the supported languages; it only improves how they are shown in the UI.

---

## What was changed

* [x] Standardized the **Language** label formatting across locales.
* [x] Fixed the inconsistency where some translations used only the native word, while others used **native word + (Language)**.
* [x] Updated the language selector to show language names in **local script + English name** format.
* [x] Kept **English** at the top of the list as the default language.
* [x] Arranged the remaining language options in ascending order for easier navigation.

> [!NOTE]
> This also makes the menu easier to recover from if a user accidentally switches to a script they cannot read.

---

## Why this matters

The previous UI used three different patterns across language-related strings:

| Area              | Previous behavior                             | New behavior                           |
| ----------------- | --------------------------------------------- | -------------------------------------- |
| Language label    | Native only or Native + English or English only | Standardized formatting [Only Native + English]               |
| Language selector | Local script only                             | Local script + English name            |
| Language order    | Mixed ordering                                | English first, others sorted ascending |

This makes the settings page look more polished and less confusing for users, especially in multilingual setups.

---

## Suggested UX rule applied

For the language selector, the display format now follows:

* **Local Script (English Name)**

Examples:

* हिंदी (Hindi)
* 日本語 (Japanese)
* Русский (Russian)
* 简体中文 (Chinese)

> [!TIP]
> This gives users a readable fallback even if they cannot understand the current script.

---

## Task list

* [x] Standardize language label formatting
* [x] Unify language selector display format
* [x] Keep English as the default first option
* [x] Sort remaining languages in ascending order
* [x] Remove locale display inconsistency