### PR TITLE
ci: modernize GitHub Actions workflows and caching

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: "recursive"
@@ -93,13 +93,13 @@ jobs:
           echo "HAS_GOOGLE_SERVICES=true" >> "$GITHUB_ENV"
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: temurin
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4.0.1
 
       - name: Accept Licenses
         run: yes | sdkmanager --licenses
@@ -111,7 +111,7 @@ jobs:
         run: sdkmanager --list
 
       - name: Setup Xmake
-        uses: xmake-io/github-action-setup-xmake@v1
+        uses: xmake-io/github-action-setup-xmake@v1.2.5
         with:
           xmake-version: "2.9.9"
           actions-cache-folder: ".xmake-cache"
@@ -141,21 +141,21 @@ jobs:
 
       - name: Upload Debug APK
         if: env.HAS_GOOGLE_SERVICES == 'true'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: LeviLauncher-debug-apk
           path: app/build/outputs/apk/debug/*.apk
 
       - name: Upload Unsigned Release APK
         if: env.HAS_GOOGLE_SERVICES == 'true'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: LeviLauncher-release-unsigned-apk
           path: app/build/outputs/apk/release/*-unsigned.apk
 
       - name: Upload Beta APK
         if: env.HAS_GOOGLE_SERVICES == 'true'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: LeviLauncher-beta-apk
           path: app/build/outputs/apk/beta/*.apk
@@ -185,14 +185,14 @@ jobs:
 
       - name: Upload Signed APK Artifact
         if: env.HAS_GOOGLE_SERVICES == 'true' && startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: LeviLauncher-${{ github.ref_name }}-release.apk
           path: LeviLauncher-${{ github.ref_name }}-release.apk
 
       - name: Release APK to GitHub Releases
         if: env.HAS_GOOGLE_SERVICES == 'true' && startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.2
         with:
           files: LeviLauncher-${{ github.ref_name }}-release.apk
         env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
+          cache: "gradle"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -32,7 +32,7 @@ jobs:
         run: npm run docs:build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist/
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    defaults:
+      run:
+        working-directory: docs
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -22,13 +25,13 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
+          cache: 'npm'
+          cache-dependency-path: 'docs/package-lock.json'
 
       - name: Install documentation dependencies
-        working-directory: docs
         run: npm ci
 
       - name: Build documentation
-        working-directory: docs
         run: npm run docs:build
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

Update the Android and documentation workflows to GitHub Actions versions compatible with the current runner runtime, and remove the deprecation warnings from CI.

## Changes

* Updated workflow actions to current major versions.
* Enabled Gradle caching in the Android workflow.
* Enabled npm caching in the docs workflow.
* Simplified the docs job by using a default working directory.

>[!NOTE]
>* The build logic are kept unchanged.

## Updated Actions

* `actions/checkout` → `v7`
* `actions/setup-java` → `v5`
* `actions/setup-node` → `v7`
* `actions/upload-artifact` → `v7`
* `actions/upload-pages-artifact` → `v5`
* `actions/deploy-pages` → `v5`
* `android-actions/setup-android` → `v4`
* `xmake-io/github-action-setup-xmake` → `v1.2.5`
* `softprops/action-gh-release` → `v3.0.2`

>This removes the `actions/setup-java@v4` deprecation warning.
This also removes the Node.js 20 warnings caused by older pinned workflow actions.

These reduces build time.

## Validation

* Android CI verified successfully.
* Docs workflow remains functionally unchanged.