### PR TITLE
Align locale strings to English reference format and fix translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ Thumbs.db
 BedrockTools-main
 tntimer-main
 MinecraftAuth
+
+# Others
+commit_msg.txt

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -69,6 +76,7 @@
     <string name="files_processed">Se procesaron correctamente %d archivos de mods</string>
     <string name="user_cancelled">Importación cancelada por el usuario</string>
 
+
     <string name="exit">Salir</string>
 
     <string name="overlay_permission_message">Por favor concede el permiso de superposición</string>
@@ -103,11 +111,12 @@
     <string name="settings_tab_migration">Migración</string>
     <string name="settings_theme_desc">Elige el tema de la aplicación</string>
 
+
     <string name="unknown_sources_permission_title">Permiso de Instalación</string>
     <string name="unknown_sources_permission_message">Para instalar o actualizar esta app, concede permiso para instalar apps desconocidas. Toca \"Conceder\" para abrir los ajustes del sistema, habilitar el permiso para esta app y volver para continuar.</string>
 
     <string name="check_update">Buscar actualizaciones</string>
-    <string name="version_prefix">Versión: </string>
+    <string name="version_prefix">Versión:</string>
     <string name="unknown_error">Error desconocido</string>
     <string name="preloader_sigs_title">Datos de tiempo de ejecución</string>
     <string name="preloader_sigs_last_update">Última actualización: %1$s</string>
@@ -131,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">Intentas iniciar una versión instalada con el aislamiento habilitado. Deshabilita el aislamiento de versión para continuar.</string>
     <string name="dialog_positive_disable">Deshabilitar</string>
     <string name="dialog_positive_ok">Aceptar</string>
+    <string name="delete_account_title">Eliminar cuenta</string>
+    <string name="delete_account_confirm">¿Seguro que quieres eliminar esta cuenta?</string>
+
 
     <string name="new_version_found">Nueva versión encontrada: %1$s</string>
     <string name="update_question">¿Quieres descargar e instalar la última versión?</string>
@@ -158,6 +170,7 @@
     <string name="repair_preparing">Preparando…</string>
     <string name="repair_processing">Extrayendo bibliotecas…</string>
     <string name="repair_finalizing">Finalizando reparación…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Migración de almacenamiento requerida</string>
     <string name="storage_migration_message">LeviLauncher debe migrar los datos de games/org.levimc a %1$s antes de continuar.
 
@@ -202,21 +215,21 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="shared_storage_layout_mode_legacy">Directorios internos/externos originales</string>
     <string name="shared_storage_layout_status">Modo actual: %1$s\nInterno: %2$s\nExterno: %3$s</string>
     <string name="shared_storage_layout_changed">La selección del directorio de almacenamiento se actualizó. Reinicia Minecraft y vuelve a abrir la gestión de contenido para aplicar completamente el cambio.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Modo de Tema</string>
     <string name="theme_follow_system">Seguir Sistema</string>
     <string name="theme_light">Modo Claro</string>
     <string name="theme_dark">Modo Oscuro</string>
 
     <string name="error_no_browser">No hay navegador disponible</string>
-
+    <!-- License & Security -->
     <string name="eula_title">Acuerdo de Licencia de LeviLauncher</string>
     <string name="eula_message"><b>Bienvenido a LeviLauncher</b>\n\nAl usar este software aceptas que:\n\n• Este es un launcher <b>no oficial</b> de Minecraft\n• Debes poseer una copia <b>con licencia</b> de Minecraft\n• Se prohíbe cualquier forma de piratería o trampa\n• Los mods/packs se usan bajo tu propio riesgo\n• No está afiliado con Mojang/Microsoft\n\nEl uso continuo constituye un acuerdo</string>
     <string name="eula_agree">Aceptar</string>
     <string name="eula_exit">Rechazar</string>
 
     <string name="allow_unknown_sources">Por favor permite la instalación desde orígenes desconocidos antes de continuar</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Eliminar versión</string>
     <string name="dialog_message_delete_version">¿Estás seguro de eliminar esta versión personalizada? Esta acción no se puede deshacer.</string>
     <string name="dialog_positive_delete">Eliminar</string>
@@ -236,7 +249,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="version_isolation">Aislamiento de Versión</string>
     <string name="launch_vertically">Iniciar verticalmente</string>
     <string name="launch_vertically_desc">Forzar inicio del juego en modo retrato (vertical)</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Ajustes de Instancia</string>
     <string name="instance_tab_general">General</string>
     <string name="instance_tab_launch_options">Opciones de Inicio</string>
@@ -247,12 +260,32 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="instance_clear_icon">Borrar</string>
     <string name="instance_icon_hint">Se guardará como LargeLogo.png en la carpeta de la versión. Toca para cambiar.</string>
     <string name="instance_isolation_desc">Aislar datos de juego para esta instancia. Otras instancias no se verán afectadas.</string>
+    <string name="instance_shortcut_title">Acceso directo en la pantalla de inicio</string>
+    <string name="instance_shortcut_desc">Los cambios de nombre e icono se guardan automáticamente. Toca Añadir acceso directo para crear o actualizar el acceso directo de la pantalla de inicio.</string>
+    <string name="instance_shortcut_name">Nombre del acceso directo</string>
+    <string name="instance_shortcut_icon">Icono del acceso directo</string>
+    <string name="instance_shortcut_choose_icon">Elegir icono</string>
+    <string name="instance_shortcut_default_icon">Usar predeterminado</string>
+    <string name="instance_shortcut_add_button">Añadir acceso directo</string>
+    <string name="instance_settings_auto_save_failed">No se pudo guardar esta configuración de la instancia.</string>
+    <string name="instance_shortcut_not_supported">Tu lanzador de pantalla de inicio no admite accesos directos fijados.</string>
+    <string name="instance_shortcut_missing">Esta instancia de Minecraft ya no está disponible.</string>
     <string name="instance_danger_zone">Zona de Peligro</string>
     <string name="instance_danger_zone_desc">Estas acciones afectan el registro o archivos locales. Revisa antes de continuar.</string>
     <string name="instance_delete_desc">Elimina permanentemente esta instancia, incluyendo mundos, configuraciones y contenido instalado.</string>
     <string name="instance_delete_warning">Esta acción no se puede deshacer.</string>
     <string name="instance_delete_confirm_title">Eliminar Instancia</string>
     <string name="instance_delete_confirm_msg">¿Estás seguro? Todos los datos, incluyendo mundos, se eliminarán permanentemente.</string>
+    <string name="instance_backup_title">Copia de seguridad de la instancia</string>
+    <string name="instance_backup_desc">Crea una copia de seguridad completa de esta instancia en Download/LeviLauncher/Backups.</string>
+    <string name="instance_backup_button">Copia de seguridad de la instancia</string>
+    <string name="instance_backup_confirm_message">¿Crear ahora una copia de seguridad completa de esta instancia? Cierra Minecraft primero si se está ejecutando para evitar cambios de archivos durante la copia.</string>
+    <string name="instance_backup_in_progress">Creando copia de seguridad de la instancia…</string>
+    <string name="instance_backup_success_title">Copia de seguridad creada</string>
+    <string name="instance_backup_success_message">Copia de seguridad guardada en:\n%1$s</string>
+    <string name="instance_backup_failed_title">Error de copia de seguridad</string>
+    <string name="instance_backup_failed_message">No se pudo crear la copia de seguridad:\n%1$s</string>
+    <string name="instance_import_backup_button">Importar copia de seguridad</string>
     <string name="instance_batch_backup_button">Copia por lotes</string>
     <string name="instance_batch_backup_title">Copia por lotes de instancias</string>
     <string name="instance_batch_backup_select_message">Selecciona las instancias que quieres respaldar. Si Minecraft está en ejecución, sal primero para evitar cambios de datos durante la copia.</string>
@@ -266,7 +299,16 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="instance_batch_backup_partial_message">Se crearon %1$d copias, %2$d fallaron.\n\nGuardadas:\n%3$s\n\nFallidas:\n%4$s</string>
     <string name="instance_batch_backup_failed_title">Error en la copia por lotes</string>
     <string name="instance_batch_backup_failed_message">No se pudo crear ninguna copia:\n%1$s</string>
+    <string name="instance_restore_title">Restaurar copia de seguridad</string>
+    <string name="instance_restore_in_progress">Restaurando copia de seguridad de la instancia…</string>
+    <string name="instance_restore_success_title">Restauración completada</string>
+    <string name="instance_restore_success_message">Restaurado: %1$s</string>
+    <string name="instance_restore_failed_title">Error de restauración</string>
+    <string name="instance_restore_failed_message">No se pudo restaurar la copia de seguridad:\n%1$s</string>
 
+    <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Idioma (Language)</string>
     <string name="english">Inglés (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -280,6 +322,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
+    <!-- Version Rename -->
     <string name="rename_version_title">Renombrar Versión</string>
     <string name="rename_version_message">Introduce un nuevo nombre para esta versión:</string>
     <string name="new_version_name">Nuevo nombre de versión</string>
@@ -288,6 +331,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="rename_failed">Error al renombrar: %1$s</string>
     <string name="cannot_rename_installed">No se puede renombrar versiones instaladas</string>
 
+    <!-- Content Management -->
     <string name="content_management">Gestión de Contenido</string>
     <string name="worlds_title">Mundos</string>
     <string name="resource_packs_title">Packs de Recursos</string>
@@ -319,6 +363,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="import_failed">Fallo al importar</string>
     <string name="import_addon_success">Addon importado: %1$d packs de recursos, %2$d packs de comportamientos</string>
 
+    <!-- World Management -->
     <string name="world_size">Tamaño: %s</string>
     <string name="world_last_played">Último juego: %s</string>
     <string name="import_world">Importar Mundo</string>
@@ -330,6 +375,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="delete">Eliminar</string>
     <string name="delete_pack">Eliminar</string>
 
+    <!-- Resource Pack Management -->
     <string name="import_resource_pack">Importar Pack de Recursos</string>
     <string name="import_behavior_pack">Importar Pack de Comportamientos</string>
     <string name="import_skin_pack">Importar Pack de Aspectos</string>
@@ -337,6 +383,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="delete_skin_pack">Eliminar Pack de Aspectos</string>
     <string name="delete_behavior_pack">Eliminar Pack de Comportamientos</string>
 
+    <!-- Content Operations -->
     <string name="confirm_delete_world">¿Seguro que quieres eliminar este mundo? No se puede deshacer.</string>
     <string name="confirm_delete_resource_pack">¿Seguro que quieres eliminar este pack de recursos? No se puede deshacer.</string>
     <string name="confirm_delete_behavior_pack">¿Seguro que quieres eliminar este pack de comportamientos? No se puede deshacer.</string>
@@ -351,9 +398,11 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="deleting_screenshot">Eliminando captura de pantalla…</string>
     <string name="deleting_server">Eliminando servidor…</string>
 
+    <!-- World Editor -->
     <string name="edit_world">Editar Mundo</string>
     <string name="edit">Editar</string>
     <string name="save">Guardar</string>
+    <string name="reset">Restablecer</string>
     <string name="saved_to_gallery">Guardado en galería</string>
     <string name="level_dat_not_found">No se encontró level.dat</string>
     <string name="no_editable_properties">No hay propiedades editables</string>
@@ -365,6 +414,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="discard_changes_message">Tienes cambios sin guardar. ¿Quieres descartarlos?</string>
     <string name="discard">Descartar</string>
 
+    <!-- Custom Flat World -->
     <string name="custom_flat_world">Mundo Plano Personalizado</string>
     <string name="world_name">Nombre del Mundo</string>
     <string name="enter_world_name">Introduce el nombre del mundo</string>
@@ -377,7 +427,22 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="add_at_least_one_layer">Añade al menos una capa</string>
     <string name="world_created_successfully">Mundo creado con éxito</string>
     <string name="failed_to_create_world">Fallo al crear mundo</string>
+    <string name="custom_flat_world_subtitle">Crea un mundo con tu propio bioma y capas de bloques</string>
+    <string name="world_settings">Configuración del mundo</string>
+    <string name="world_settings_hint">Elige la configuración básica del nuevo mundo</string>
+    <string name="layers_title">Capas</string>
+    <string name="add_layer_compact">Añadir capa</string>
+    <string name="no_layers_title">Aún no hay capas</string>
+    <string name="no_layers_hint">Añade al menos una capa de bloques para crear el mundo</string>
+    <string name="reorder_layer">Reordenar capa</string>
+    <string name="delete_layer">Eliminar capa</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d capa • abajo → arriba</item>
+        <item quantity="other">%1$d capas • abajo → arriba</item>
+    </plurals>
 
+    <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Se requiere versión de Play Store</string>
     <string name="minecraft_playstore_required_message">Este launcher solo funciona con la app oficial de Minecraft desde Google Play Store. Por favor instálala para continuar.</string>
     <string name="buy_minecraft">Obtener Minecraft</string>
@@ -387,11 +452,59 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="genuine_badge_label">Licencia no verificada</string>
     <string name="invalid_license_detected_toast">Minecraft no original detectado. Asegúrate de tener Minecraft de Google Play Store</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Total de Mods:</string>
     <string name="enabled_mods">Habilitados:</string>
     <string name="add_mod">Añadir Mod</string>
+    <string name="scan_downloads">Escanear</string>
+    <string name="scan_downloads_scanning">Escaneando…</string>
+    <string name="scan_downloads_none_found">No se encontraron mods .levipack ni .so en Descargas</string>
+    <string name="scan_downloads_failed">No se pudo escanear Descargas</string>
+    <string name="scan_downloads_permission_denied">Se necesita acceso al almacenamiento para escanear Descargas</string>
+    <string name="scan_downloads_results_title">Mods en Descargas</string>
+    <string name="scan_downloads_results_subtitle">Elige un mod para añadir. El escaneo solo revisa la carpeta principal de Descargas.</string>
+    <string name="scan_downloads_add">Añadir</string>
+    <string name="scan_downloads_adding">Añadiendo…</string>
+    <string name="scan_downloads_added">Añadido</string>
+    <string name="scan_downloads_added_message">%1$s añadido</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Biblioteca nativa</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Mods externos</string>
+    <string name="external_mods_subtitle">Mods de la comunidad para Minecraft %1$s</string>
+    <string name="external_mods_no_version">Selecciona una versión de Minecraft antes de instalar mods</string>
+    <string name="external_mods_search_hint">Buscar mods, autores o versiones…</string>
+    <string name="external_mods_compatible_only">Solo compatibles</string>
+    <string name="external_mods_all_versions">Todas las versiones de Minecraft</string>
+    <string name="external_mods_sort_newest">Más recientes</string>
+    <string name="external_mods_sort_name">Nombre A–Z</string>
+    <string name="external_mods_empty">Ningún mod coincide con estos filtros</string>
+    <string name="external_mods_load_failed">No se pudo actualizar el catálogo. Se muestra la copia guardada.</string>
+    <string name="external_mods_refresh">Actualizar catálogo</string>
+    <string name="external_mods_refreshed">Catálogo actualizado</string>
+    <string name="external_mods_join_discord">Unirse al Discord de la comunidad</string>
+    <string name="external_mods_discord_open_failed">Ninguna aplicación puede abrir la invitación de Discord</string>
+    <string name="external_mods_download">Descargando %1$s</string>
+    <string name="external_mods_importing">Importando mod…</string>
+    <string name="external_mods_installed">%1$s instalado</string>
+    <string name="external_mods_install_failed">No se pudo instalar %1$s: %2$s</string>
+    <string name="external_mods_open_failed">Ningún navegador puede abrir esta descarga</string>
+    <string name="external_mods_direct_download">Descarga directa</string>
+    <string name="external_mods_ad_download">Descarga con anuncios</string>
+    <string name="external_mods_external_link">Enlace externo</string>
+    <string name="external_mods_open_link">Abrir enlace</string>
+    <string name="external_mods_external_dialog_title">Descarga externa</string>
+    <string name="external_mods_ad_dialog_title">Descarga con anuncios</string>
+    <string name="external_mods_external_dialog_message">%1$s usa una página de descarga fuera de LeviLauncher.\n\n1. Toca Abrir enlace y descarga el archivo .levipack o .so.\n2. Vuelve a LeviLauncher y abre Mods.\n3. Toca Escanear.\n4. Toca Añadir junto al mod que quieras importar.\n\nEl escaneo solo revisa la carpeta principal de Descargas. Mueve el archivo allí si tu navegador lo guardó en otro lugar.</string>
+    <string name="external_mods_ad_dialog_message">%1$s usa una página de descarga con anuncios elegida por su desarrollador. LeviLauncher no controla esa página ni sus anuncios.\n\n1. Toca Abrir enlace y descarga el archivo .levipack o .so.\n2. Vuelve a LeviLauncher y abre Mods.\n3. Toca Escanear.\n4. Toca Añadir junto al mod que quieras importar.\n\nEl escaneo solo revisa la carpeta principal de Descargas. Descarga únicamente el archivo del mod; no instales aplicaciones no relacionadas ni permitas notificaciones.</string>
+    <string name="external_mods_by_author">por %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Actualizar</string>
+    <string name="external_mods_installed_button">Instalado</string>
+    <string name="external_mods_incompatible">Incompatible</string>
 
+    <!-- Mod Detail -->
     <string name="mod_detail_title">Detalles del Mod</string>
     <string name="delete_mod">Eliminar Mod</string>
     <string name="error_loading_mod">Error al cargar los detalles</string>
@@ -399,10 +512,63 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="mod_disabled">Mod deshabilitado</string>
     <string name="mod_filename_format">Archivo: %s</string>
     <string name="mod_enable_status">Estado de Habilitación</string>
+    <string name="mod_icon_content_description">Icono del mod</string>
+    <string name="mod_author_byline">por %s</string>
+    <string name="mod_version_chip">Versión %s</string>
+    <string name="mod_metadata_title">Información</string>
+    <string name="mod_actions_title">Acciones</string>
+    <string name="mod_author_label">Autor</string>
+    <string name="mod_version_label">Versión</string>
+    <string name="mod_minecraft_versions_label">Versiones de Minecraft</string>
+    <string name="mod_entry_label">Archivo de entrada</string>
+    <string name="mod_id_label">ID del mod</string>
+    <string name="mod_config_files_label">Archivos de configuración</string>
+    <string name="mod_unknown_author">Autor desconocido</string>
+    <string name="mod_unknown_version">Versión desconocida</string>
+    <string name="mod_all_versions">Todas las versiones compatibles</string>
+    <string name="mod_no_config_files">No hay configuración editable</string>
+    <string name="mod_config_badge">CONFIG</string>
+    <string name="mod_config_badge_with_count">CONFIG · %d</string>
+    <string name="mod_config_title_format">Configuración de %s</string>
+    <string name="mod_config_not_found">No se encontró configuración editable</string>
+    <string name="mod_config_load_failed">Error al cargar la configuración: %s</string>
+    <string name="mod_config_save_failed">Error al guardar la configuración</string>
+    <string name="mod_config_saved">Configuración guardada</string>
+    <string name="mod_config_restart_hint">El archivo de configuración se guardó y se conservó un archivo .backup.</string>
+    <string name="mod_config_validation_failed">La validación de configuración falló</string>
+    <string name="mod_config_invalid_json">JSON no válido</string>
+    <string name="mod_config_expand">Expandir</string>
+    <string name="mod_config_collapse">Contraer</string>
+    <string name="mod_config_raw_json">Editar JSON original</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">Elemento %1$s</string>
+    <string name="mod_config_object_desc">Grupo de ajustes relacionados</string>
+    <string name="mod_config_array_desc">Lista de valores</string>
+    <string name="mod_config_range_prefix">Rango</string>
+    <string name="mod_config_error_number">%1$s debe ser un número</string>
+    <string name="mod_config_error_minimum">%1$s debe ser al menos %2$s</string>
+    <string name="mod_config_error_maximum">%1$s debe ser como máximo %2$s</string>
+    <string name="mod_config_error_boolean">%1$s debe estar activado o desactivado</string>
+    <string name="mod_config_error_string">%1$s debe ser texto</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d configuración editable</item>
+        <item quantity="other">%d configuraciones editables</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d opción</item>
+        <item quantity="other">%d opciones</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d elemento</item>
+        <item quantity="other">%d elementos</item>
+    </plurals>
 
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">Seleccionar Versión del Juego</string>
     <string name="back">Atrás</string>
 
+    <!-- Splash -->
     <string name="splash_logo_desc">Logo de hoja</string>
     <string name="minecraft_loading_title">Iniciando Minecraft</string>
     <string name="minecraft_loading_subtitle">Preparando bibliotecas nativas y mods habilitados</string>
@@ -416,6 +582,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="launcher_restart_subtitle">Espera un momento, volverás a la pantalla principal</string>
     <string name="launcher_restart_status">Ya casi…</string>
 
+    <!-- Accounts & Microsoft Login -->
     <string name="accounts_title">Cuentas</string>
     <string name="microsoft_accounts">Cuentas de Microsoft</string>
     <string name="manage_accounts">Gestionar cuentas</string>
@@ -426,13 +593,45 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="accounts_active_privilege">Sesión iniciada</string>
 
     <string name="ms_login_title">Inicio de sesión Microsoft</string>
+    <string name="ms_login_header_subtitle">Inicia sesión de forma segura en Minecraft</string>
     <string name="ms_login_starting">Iniciando sesión con Microsoft…</string>
     <string name="ms_login_exchanging">Intercambiando token…</string>
     <string name="ms_login_auth_xbox_device">Autenticando dispositivo Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Obteniendo identidad de Minecraft…</string>
+    <string name="ms_login_retrying">Conexión interrumpida. Reintentando de forma segura…</string>
     <string name="ms_login_success">Sesión iniciada como %1$s</string>
     <string name="ms_login_failed">Fallo de inicio de sesión</string>
     <string name="ms_login_failed_detail">Fallo al iniciar sesión: %1$s</string>
+    <string name="ms_choose_login_method">Iniciar sesión en Minecraft</string>
+    <string name="ms_choose_login_method_desc">Elige el flujo de código de dispositivo basado en navegador o continúa con la página de Microsoft integrada.</string>
+    <string name="ms_device_code_login">Continuar con el navegador</string>
+    <string name="ms_device_code_option_title">Código de dispositivo (recomendado)</string>
+    <string name="ms_device_code_login_desc">Abre una sesión privada del navegador con el código de dispositivo ya rellenado.</string>
+    <string name="ms_webview_login">Abrir inicio de sesión integrado</string>
+    <string name="ms_webview_option_title">WebView integrado</string>
+    <string name="ms_webview_login_desc">Inicia sesión sin salir de LeviLauncher. Úsalo cuando el flujo del navegador no esté disponible.</string>
+    <string name="ms_device_code_title">Iniciar sesión con código de dispositivo</string>
+    <string name="ms_device_code_instructions">Abre la página de inicio de sesión de dispositivos de Microsoft, introduce este código y aprueba el acceso. LeviLauncher finalizará automáticamente.</string>
+    <string name="ms_device_code_label">Código de dispositivo de Microsoft</string>
+    <string name="ms_device_code_requesting">Solicitando un código seguro…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Esperando a que termines en el navegador…</string>
+    <string name="ms_device_code_checking">Comprobando el resultado del inicio de sesión de Microsoft…</string>
+    <string name="ms_device_code_reconnecting">La conexión cambió. Reintentando automáticamente…</string>
+    <string name="ms_device_code_authorized">Microsoft aprobó el inicio de sesión. Finalizando…</string>
+    <string name="ms_device_code_browser_opened">Completa el nuevo inicio de sesión de Microsoft en tu navegador y luego vuelve aquí.</string>
+    <string name="ms_device_code_expires">El código caduca en %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Copiar código</string>
+    <string name="ms_device_code_copied">Código copiado</string>
+    <string name="ms_device_code_open_browser">Abrir inicio de sesión de Microsoft</string>
+    <string name="ms_device_code_step_title">Completa el inicio de sesión en tu navegador</string>
+    <string name="ms_device_code_browser_note">LeviLauncher abre tu navegador predeterminado en una sesión privada, rellena el código automáticamente y solicita un nuevo inicio de sesión de Microsoft.</string>
+    <string name="ms_choose_other_method">Otro método</string>
+    <string name="ms_no_browser">No hay ningún navegador disponible en este dispositivo.</string>
+    <string name="ms_default_browser_no_private_mode">Tu navegador predeterminado no admite inicio de sesión privado. Actualízalo o usa el inicio de sesión con WebView.</string>
+    <string name="ms_login_ssl_failed">No se pudo verificar la página segura de inicio de sesión de Microsoft.</string>
+    <string name="ms_login_state_failed">No se pudo verificar la respuesta de inicio de sesión de Microsoft. Inicia sesión de nuevo.</string>
+    <string name="ms_login_missing_code">Microsoft no devolvió un código de inicio de sesión. Inicia sesión de nuevo o usa Código de dispositivo.</string>
 
     <string name="ms_set_active">Establecer Activa</string>
     <string name="ms_delete">Eliminar</string>
@@ -445,9 +644,14 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="go_to_accounts">Cuentas</string>
     <string name="disable_launcher_login_and_continue">Cerrar</string>
 
+    <string name="ms_feature_disabled_title">Función desactivada</string>
+    <string name="ms_feature_disabled_desc">Activa «Iniciar sesión en Minecraft con LeviLauncher» en Ajustes para administrar cuentas de Microsoft.</string>
+    <string name="ms_activated">Activado</string>
+
+    <!-- Popup labels -->
     <string name="label_current_account">Cuenta Actual</string>
     <string name="label_other_accounts">Otras Cuentas</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">La aplicación se bloqueó</string>
     <string name="crash_upload">Subir informe de bloqueo</string>
     <string name="crash_details_title">Detalles del bloqueo</string>
@@ -466,8 +670,15 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="dialog_message_exit_app">¿Estás seguro de que deseas salir?</string>
     <string name="dialog_positive_exit">Salir</string>
     <string name="show_logcat_overlay">Superposición Logcat</string>
+    <string name="foreground_service">Servicio en primer plano</string>
+    <string name="foreground_service_desc">Mantén Minecraft en ejecución al cambiar de aplicación evitando que Bedrock suspenda la sesión activa y manteniendo activos el proceso, la CPU y el Wi-Fi.</string>
+    <string name="foreground_service_warning">Nota: Puede hacer que tu teléfono se caliente más rápido y aumentar el consumo de batería.</string>
+    <string name="foreground_service_channel">Protección de Minecraft en segundo plano</string>
+    <string name="foreground_service_notification_title">Minecraft se mantiene activo</string>
+    <string name="foreground_service_notification_text">El modo en segundo plano de Minecraft está activo. La CPU y el acceso a la red se mantienen disponibles para la sesión actual.</string>
     <string name="logcat_live">Logcat: <b>en vivo</b></string>
     <string name="logcat_paused">Logcat: en pausa</string>
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">Filtro de palabra clave</string>
     <string name="logcat_blacklist_hint">Lista negra (separada por comas)</string>
     <string name="logcat_filter_clear">Borrar filtros</string>
@@ -479,6 +690,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="logcat_corner_bottom_left">Redimensionar: abajo-izq</string>
     <string name="logcat_corner_bottom_right">Redimensionar: abajo-der</string>
 
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mods">Mods Incorporados</string>
     <string name="inbuilt_mods_title">Mods Incorporados</string>
     <string name="inbuilt_mods_subtitle">Mods internos que funcionan sin bibliotecas nativas</string>
@@ -487,7 +699,8 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="inbuilt_mod_removed">%s eliminado de los mods</string>
     <string name="add">Añadir</string>
     <string name="remove">Quitar</string>
-
+    
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">Dejar caer rápido</string>
     <string name="inbuilt_mod_quick_drop_desc">Suelta objetos rápidamente</string>
     <string name="inbuilt_mod_camera">Perspectiva Rápida</string>
@@ -515,16 +728,25 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="virtual_cursor_enabled">Cursor habilitado</string>
     <string name="virtual_cursor_disabled">Cursor deshabilitado</string>
     <string name="cursor_sensitivity_label">Sensibilidad del Cursor:</string>
+    <string name="inbuilt_mod_gyro">Giroscopio</string>
+    <string name="inbuilt_mod_gyro_desc">Usa el giroscopio del dispositivo para controlar la rotación de la cámara</string>
+    <string name="inbuilt_mod_pojav_controls">Controles de Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Reemplaza los controles táctiles de Minecraft por controles totalmente personalizables al estilo Pojav</string>
+    <string name="inbuilt_mod_more_buttons">Más botones</string>
+    <string name="inbuilt_mod_more_buttons_desc">Crea botones personalizados en pantalla con asignaciones de una sola tecla e iconos SVG</string>
     <string name="inbuilt_badge">INCORPORADO</string>
     <string name="autosprint_keybind_label">Tecla Auto Sprint:</string>
     <string name="autosprint_keybind_press">Presiona cualquier tecla…</string>
     <string name="configure">Configurar</string>
     <string name="overlay_button_size">Tamaño de Botón Overlay</string>
     <string name="overlay_button_opacity">Opacidad de Botón Overlay</string>
+    <string name="overlay_button_size_value">Tamaño: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Opacidad: %1$d%%</string>
     <string name="overlay_button_lock">Bloquear Posición</string>
     <string name="overlay_button_lock_desc">Prevenir arrastres y activaciones accidentales</string>
     <string name="settings">Ajustes</string>
 
+    <!-- Extract Structures -->
     <string name="extract_structures">Extraer Estructuras</string>
     <string name="no_structures_found">No se encontraron estructuras en este mundo</string>
     <string name="no_structures_found_title">Sin Estructuras Encontradas</string>
@@ -538,15 +760,36 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="structures_found_title">Estructuras Encontradas</string>
     <string name="structures_found_count">%d estructuras encontradas en este mundo</string>
 
+    <!-- Mod Menu -->
     <string name="mod_menu">Menú de Mods</string>
     <string name="mod_menu_modules">Módulos</string>
+    <string name="mod_menu_favorites">Favoritos</string>
+    <string name="mod_menu_favorite">Añadir a favoritos</string>
+    <string name="mod_menu_unfavorite">Quitar de favoritos</string>
+    <string name="mod_menu_hud_editor">Editor de HUD</string>
+    <string name="mod_menu_filter_enabled">Activados</string>
+    <string name="mod_menu_filter_inbuilt">Integrados</string>
+    <string name="mod_menu_filter_external">Externos</string>
     <string name="mod_menu_search_hint">Buscar mods…</string>
     <string name="mod_menu_no_mods">No hay mods añadidos</string>
+    <string name="mod_menu_no_favorites">Aún no hay mods favoritos</string>
+    <string name="mod_menu_no_matches">No hay mods coincidentes</string>
+    <string name="mod_menu_group_inbuilt">Funciones integradas</string>
+    <string name="mod_menu_group_external_ungrouped">Mods externos sin agrupar</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Ajustes generales</string>
+    <string name="mod_menu_appearance">Apariencia</string>
+    <string name="mod_menu_pause_menu_only">Solo en menú de pausa</string>
+    <string name="mod_menu_pause_menu_only_desc">Mostrar el menú de mods solo en la pantalla de pausa</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Ajustes próximamente</string>
     <string name="mod_menu_notifications">Notificaciones</string>
     <string name="mod_menu_notifications_desc">Mostrar notificación al habilitar mods</string>
     <string name="mod_menu_opacity">Opacidad del Menú de Mods</string>
     <string name="mod_menu_button_opacity">Opacidad del Botón Menú</string>
+    <string name="mod_menu_compact">Menú de mods compacto</string>
+    <string name="mod_menu_compact_desc">Usa un menú más pequeño con una lista de módulos densa y filtros compactos</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Menú de Mods habilitado</string>
     <string name="mod_menu_disabled">Menú de Mods deshabilitado</string>
@@ -555,7 +798,37 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="mod_status_enabled">Habilitado</string>
     <string name="mod_status_disabled">Deshabilitado</string>
     <string name="mod_notification_enabled">%s habilitado</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Tamaño del botón superpuesto (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacidad de superposición (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Mostrar en todas partes</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilidad del cursor (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Nivel de zoom (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Tecla de sprint automático</string>
+    <string name="mod_config_zoom_keybind">Tecla de zoom</string>
+    <string name="mod_config_zoom_transition">Duración de la transición (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicador de sensibilidad (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Velocidad horizontal (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Velocidad vertical (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Filtro de movimientos pequeños (0 = Desactivado)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilidad horizontal (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilidad vertical (%)</string>
+    <string name="mod_config_gyro_invert_x">Invertir eje horizontal</string>
+    <string name="mod_config_gyro_invert_y">Invertir eje vertical</string>
+    <string name="mod_config_gyro_deadzone">Zona muerta</string>
+    <string name="mod_config_press_any_key">Presiona cualquier tecla para asignar...</string>
+    <string name="mod_config_key_unknown">DESCONOCIDO</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Arrastra para mover el panel</string>
+    <string name="hud_editor_drag_description">Editor de HUD. Arrastra esta zona para mover el panel.</string>
 
+    <!-- Options Editor -->
     <string name="edit_options">Editar Opciones</string>
     <string name="options_file_not_found">Archivo de opciones no encontrado</string>
     <string name="no_options_found">No se encontraron opciones</string>
@@ -564,6 +837,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="error_loading_options">Error al cargar opciones</string>
     <string name="options_saved">Opciones guardadas con éxito</string>
 
+    <!-- Quick Launch -->
     <string name="quick_launch_title">Lanzamiento Rápido</string>
     <string name="quick_launch_subtitle">Inicia Minecraft con acciones específicas usando URI</string>
     <string name="quick_launch_how_to_play">Cómo Jugar</string>
@@ -591,6 +865,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="quick_launch_custom_uri">URI Personalizada</string>
     <string name="quick_launch_custom_uri_desc">Ingresa una URI de minecraft://</string>
 
+    <!-- Quick Launch Dialogs -->
     <string name="server_ip_hint">Dirección IP del Servidor</string>
     <string name="server_port_hint">Puerto (por defecto: 19132)</string>
     <string name="server_name_hint">Nombre del Servidor</string>
@@ -602,6 +877,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="custom_uri_hint">Ingresa URI completa. Ej:\nminecraft://openStore\nminecraft://?showStoreOffer=UUID</string>
     <string name="select_tab">Seleccionar Pestaña:</string>
 
+    <!-- Quick Launch Validation -->
     <string name="server_ip_required">IP requerida</string>
     <string name="server_details_required">Nombre e IP de servidor requeridos</string>
     <string name="invalid_port">Número de puerto inválido</string>
@@ -610,14 +886,17 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="command_required">Comando requerido</string>
     <string name="invalid_minecraft_uri">URI inválida</string>
 
+    <!-- Quick Launch Actions -->
     <string name="connect">Conectar</string>
     <string name="join">Unirse</string>
     <string name="load">Cargar</string>
     <string name="execute">Ejecutar</string>
 
+    <!-- Quick Actions Menu -->
     <string name="quick_launch">Lanzamiento Rápido</string>
     <string name="quick_launch_menu_subtitle">Inicia con acciones URI</string>
 
+    <!-- CurseForge -->
     <string name="curseforge_title">CurseForge</string>
     <string name="curseforge_subtitle">Navegar y descargar contenidos</string>
     <string name="curseforge_search_hint">Buscar contenidos…</string>
@@ -627,6 +906,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="curseforge_download_failed">Descarga fallida</string>
     <string name="curseforge_available_files">Archivos Disponibles</string>
 
+    <!-- Navigation Bar -->
     <string name="nav_launch">Jugar</string>
     <string name="nav_import">Importar</string>
     <string name="nav_instances">Instancias</string>
@@ -673,7 +953,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
         <item>CurseForge te permite navegar y descargar contenido de la comunidad directamente.</item>
         <item>Carga módulos SO externos para extender o mejorar el rendimiento de Minecraft.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Color del Tema</string>
     <string name="theme_color_desc">El color de acento primario de la aplicación</string>
     <string name="preset_colors">COLORES PREDETERMINADOS</string>
@@ -691,163 +971,8 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
 
     <string name="unsupported_version_title">Versión no soportada</string>
     <string name="unsupported_version_msg">Este lanzador no soporta versiones de Minecraft anteriores a 1.21.80.</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">por %s</string>
-    <string name="mod_version_chip">Versión %s</string>
-    <string name="mod_config_title_format">Configuración de %s</string>
-    <string name="mod_config_not_found">No se encontró configuración editable</string>
-    <string name="mod_config_load_failed">Error al cargar la configuración: %s</string>
-    <string name="mod_config_save_failed">Error al guardar la configuración</string>
-    <string name="mod_config_saved">Configuración guardada</string>
-    <string name="mod_config_restart_hint">El archivo de configuración se guardó y se conservó un archivo .backup.</string>
-    <string name="mod_config_validation_failed">La validación de configuración falló</string>
-    <string name="mod_config_invalid_json">JSON no válido</string>
-    <string name="mod_config_expand">Expandir</string>
-    <string name="mod_config_collapse">Contraer</string>
-    <string name="mod_config_raw_json">Editar JSON original</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">Elemento %1$s</string>
-    <string name="mod_config_object_desc">Grupo de ajustes relacionados</string>
-    <string name="mod_config_array_desc">Lista de valores</string>
-    <string name="mod_config_range_prefix">Rango</string>
-    <string name="mod_config_error_number">%1$s debe ser un número</string>
-    <string name="mod_config_error_minimum">%1$s debe ser al menos %2$s</string>
-    <string name="mod_config_error_maximum">%1$s debe ser como máximo %2$s</string>
-    <string name="mod_config_error_boolean">%1$s debe estar activado o desactivado</string>
-    <string name="mod_config_error_string">%1$s debe ser texto</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d configuración editable</item>
-        <item quantity="other">%d configuraciones editables</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d opción</item>
-        <item quantity="other">%d opciones</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d elemento</item>
-        <item quantity="other">%d elementos</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Favoritos</string>
-    <string name="mod_menu_favorite">Añadir a favoritos</string>
-    <string name="mod_menu_unfavorite">Quitar de favoritos</string>
-    <string name="mod_menu_hud_editor">Editor de HUD</string>
-    <string name="mod_menu_filter_enabled">Activados</string>
-    <string name="mod_menu_filter_inbuilt">Integrados</string>
-    <string name="mod_menu_filter_external">Externos</string>
-    <string name="mod_menu_no_favorites">Aún no hay mods favoritos</string>
-    <string name="mod_menu_no_matches">No hay mods coincidentes</string>
-    <string name="mod_menu_group_inbuilt">Funciones integradas</string>
-    <string name="mod_menu_group_external_ungrouped">Mods externos sin agrupar</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Ajustes generales</string>
-    <string name="mod_menu_appearance">Apariencia</string>
-    <string name="mod_menu_pause_menu_only">Solo en menú de pausa</string>
-    <string name="mod_menu_pause_menu_only_desc">Mostrar el menú de mods solo en la pantalla de pausa</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Tamaño del botón superpuesto (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacidad de superposición (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilidad del cursor (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Nivel de zoom (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Tecla de sprint automático</string>
-    <string name="mod_config_zoom_keybind">Tecla de zoom</string>
-    <string name="mod_config_press_any_key">Presiona cualquier tecla para asignar...</string>
-    <string name="mod_config_key_unknown">DESCONOCIDO</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Tamaño: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Opacidad: %1$d%%</string>
-    <string name="reset">Restablecer</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Eliminar cuenta</string>
-    <string name="delete_account_confirm">¿Seguro que quieres eliminar esta cuenta?</string>
-    <string name="instance_backup_title">Copia de seguridad de la instancia</string>
-    <string name="instance_backup_desc">Crea una copia de seguridad completa de esta instancia en Download/LeviLauncher/Backups.</string>
-    <string name="instance_backup_button">Copia de seguridad de la instancia</string>
-    <string name="instance_backup_confirm_message">¿Crear ahora una copia de seguridad completa de esta instancia? Cierra Minecraft primero si se está ejecutando para evitar cambios de archivos durante la copia.</string>
-    <string name="instance_backup_in_progress">Creando copia de seguridad de la instancia…</string>
-    <string name="instance_backup_success_title">Copia de seguridad creada</string>
-    <string name="instance_backup_success_message">Copia de seguridad guardada en:\n%1$s</string>
-    <string name="instance_backup_failed_title">Error de copia de seguridad</string>
-    <string name="instance_backup_failed_message">No se pudo crear la copia de seguridad:\n%1$s</string>
-    <string name="instance_import_backup_button">Importar copia de seguridad</string>
-    <string name="instance_restore_title">Restaurar copia de seguridad</string>
-    <string name="instance_restore_in_progress">Restaurando copia de seguridad de la instancia…</string>
-    <string name="instance_restore_success_title">Restauración completada</string>
-    <string name="instance_restore_success_message">Restaurado: %1$s</string>
-    <string name="instance_restore_failed_title">Error de restauración</string>
-    <string name="instance_restore_failed_message">No se pudo restaurar la copia de seguridad:\n%1$s</string>
-    <string name="mod_icon_content_description">Icono del mod</string>
-    <string name="mod_metadata_title">Información</string>
-    <string name="mod_actions_title">Acciones</string>
-    <string name="mod_author_label">Autor</string>
-    <string name="mod_version_label">Versión</string>
-    <string name="mod_minecraft_versions_label">Versiones de Minecraft</string>
-    <string name="mod_entry_label">Archivo de entrada</string>
-    <string name="mod_id_label">ID del mod</string>
-    <string name="mod_config_files_label">Archivos de configuración</string>
-    <string name="mod_unknown_author">Autor desconocido</string>
-    <string name="mod_unknown_version">Versión desconocida</string>
-    <string name="mod_all_versions">Todas las versiones compatibles</string>
-    <string name="mod_no_config_files">No hay configuración editable</string>
-    <string name="mod_config_badge">CONFIG</string>
-    <string name="mod_config_badge_with_count">CONFIG · %d</string>
-    <string name="ms_login_header_subtitle">Inicia sesión de forma segura en Minecraft</string>
-    <string name="ms_login_retrying">Conexión interrumpida. Reintentando de forma segura…</string>
-    <string name="ms_choose_login_method">Iniciar sesión en Minecraft</string>
-    <string name="ms_choose_login_method_desc">Elige el flujo de código de dispositivo basado en navegador o continúa con la página de Microsoft integrada.</string>
-    <string name="ms_device_code_login">Continuar con el navegador</string>
-    <string name="ms_device_code_option_title">Código de dispositivo (recomendado)</string>
-    <string name="ms_device_code_login_desc">Abre una sesión privada del navegador con el código de dispositivo ya rellenado.</string>
-    <string name="ms_webview_login">Abrir inicio de sesión integrado</string>
-    <string name="ms_webview_option_title">WebView integrado</string>
-    <string name="ms_webview_login_desc">Inicia sesión sin salir de LeviLauncher. Úsalo cuando el flujo del navegador no esté disponible.</string>
-    <string name="ms_device_code_title">Iniciar sesión con código de dispositivo</string>
-    <string name="ms_device_code_instructions">Abre la página de inicio de sesión de dispositivos de Microsoft, introduce este código y aprueba el acceso. LeviLauncher finalizará automáticamente.</string>
-    <string name="ms_device_code_label">Código de dispositivo de Microsoft</string>
-    <string name="ms_device_code_requesting">Solicitando un código seguro…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Esperando a que termines en el navegador…</string>
-    <string name="ms_device_code_checking">Comprobando el resultado del inicio de sesión de Microsoft…</string>
-    <string name="ms_device_code_reconnecting">La conexión cambió. Reintentando automáticamente…</string>
-    <string name="ms_device_code_authorized">Microsoft aprobó el inicio de sesión. Finalizando…</string>
-    <string name="ms_device_code_browser_opened">Completa el nuevo inicio de sesión de Microsoft en tu navegador y luego vuelve aquí.</string>
-    <string name="ms_device_code_expires">El código caduca en %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Copiar código</string>
-    <string name="ms_device_code_copied">Código copiado</string>
-    <string name="ms_device_code_open_browser">Abrir inicio de sesión de Microsoft</string>
-    <string name="ms_device_code_step_title">Completa el inicio de sesión en tu navegador</string>
-    <string name="ms_device_code_browser_note">LeviLauncher abre tu navegador predeterminado en una sesión privada, rellena el código automáticamente y solicita un nuevo inicio de sesión de Microsoft.</string>
-    <string name="ms_choose_other_method">Otro método</string>
-    <string name="ms_no_browser">No hay ningún navegador disponible en este dispositivo.</string>
-    <string name="ms_default_browser_no_private_mode">Tu navegador predeterminado no admite inicio de sesión privado. Actualízalo o usa el inicio de sesión con WebView.</string>
-    <string name="ms_login_ssl_failed">No se pudo verificar la página segura de inicio de sesión de Microsoft.</string>
-    <string name="ms_login_state_failed">No se pudo verificar la respuesta de inicio de sesión de Microsoft. Inicia sesión de nuevo.</string>
-    <string name="ms_login_missing_code">Microsoft no devolvió un código de inicio de sesión. Inicia sesión de nuevo o usa Código de dispositivo.</string>
-    <string name="ms_feature_disabled_title">Función desactivada</string>
-    <string name="ms_feature_disabled_desc">Activa «Iniciar sesión en Minecraft con LeviLauncher» en Ajustes para administrar cuentas de Microsoft.</string>
-    <string name="ms_activated">Activado</string>
-    <string name="inbuilt_mod_gyro">Giroscopio</string>
-    <string name="inbuilt_mod_gyro_desc">Usa el giroscopio del dispositivo para controlar la rotación de la cámara</string>
-    <string name="inbuilt_mod_pojav_controls">Controles de Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Reemplaza los controles táctiles de Minecraft por controles totalmente personalizables al estilo Pojav</string>
-    <string name="inbuilt_mod_more_buttons">Más botones</string>
-    <string name="inbuilt_mod_more_buttons_desc">Crea botones personalizados en pantalla con asignaciones de una sola tecla e iconos SVG</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Mostrar en todas partes</string>
-    <string name="mod_config_zoom_transition">Duración de la transición (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilidad horizontal (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilidad vertical (%)</string>
-    <string name="mod_config_gyro_invert_x">Invertir eje horizontal</string>
-    <string name="mod_config_gyro_invert_y">Invertir eje vertical</string>
-    <string name="mod_config_gyro_deadzone">Zona muerta</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Cerrar</string>
     <string name="previous">Anterior</string>
     <string name="next">Siguiente</string>
@@ -897,6 +1022,8 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="custom_color_hint">#RRGGBB o R,G,B</string>
     <string name="screenshot_name_placeholder">Nombre de la captura de pantalla</string>
     <string name="screenshot_date_placeholder">Fecha: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Crea botones en pantalla con estilo de Minecraft asignados exactamente a una tecla de teclado cada uno. Los botones nunca ejecutan macros, secuencias de teclas, repeticiones automáticas ni autoclic.</string>
     <string name="more_buttons_add_button">Añadir botón</string>
     <string name="more_buttons_limit_reached">Se alcanzó el máximo de %1$d botones personalizados.</string>
@@ -954,99 +1081,17 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="more_buttons_no_svg_selected">Ningún SVG seleccionado</string>
     <string name="more_buttons_default_name">Botón</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Ranura de la barra rápida</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Añade botones separados del 1 al 9 para seleccionar ranuras de la barra rápida</string>
     <string name="hotbar_slot_content_description">Ranura de la barra rápida %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Acceso directo en la pantalla de inicio</string>
-    <string name="instance_shortcut_desc">Los cambios de nombre e icono se guardan automáticamente. Toca Añadir acceso directo para crear o actualizar el acceso directo de la pantalla de inicio.</string>
-    <string name="instance_shortcut_name">Nombre del acceso directo</string>
-    <string name="instance_shortcut_icon">Icono del acceso directo</string>
-    <string name="instance_shortcut_choose_icon">Elegir icono</string>
-    <string name="instance_shortcut_default_icon">Usar predeterminado</string>
-    <string name="instance_shortcut_add_button">Añadir acceso directo</string>
-    <string name="instance_settings_auto_save_failed">No se pudo guardar esta configuración de la instancia.</string>
-    <string name="instance_shortcut_not_supported">Tu lanzador de pantalla de inicio no admite accesos directos fijados.</string>
-    <string name="instance_shortcut_missing">Esta instancia de Minecraft ya no está disponible.</string>
-    <string name="custom_flat_world_subtitle">Crea un mundo con tu propio bioma y capas de bloques</string>
-    <string name="world_settings">Configuración del mundo</string>
-    <string name="world_settings_hint">Elige la configuración básica del nuevo mundo</string>
-    <string name="layers_title">Capas</string>
-    <string name="add_layer_compact">Añadir capa</string>
-    <string name="no_layers_title">Aún no hay capas</string>
-    <string name="no_layers_hint">Añade al menos una capa de bloques para crear el mundo</string>
-    <string name="reorder_layer">Reordenar capa</string>
-    <string name="delete_layer">Eliminar capa</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Escanear</string>
-    <string name="scan_downloads_scanning">Escaneando…</string>
-    <string name="scan_downloads_none_found">No se encontraron mods .levipack ni .so en Descargas</string>
-    <string name="scan_downloads_failed">No se pudo escanear Descargas</string>
-    <string name="scan_downloads_permission_denied">Se necesita acceso al almacenamiento para escanear Descargas</string>
-    <string name="scan_downloads_results_title">Mods en Descargas</string>
-    <string name="scan_downloads_results_subtitle">Elige un mod para añadir. El escaneo solo revisa la carpeta principal de Descargas.</string>
-    <string name="scan_downloads_add">Añadir</string>
-    <string name="scan_downloads_adding">Añadiendo…</string>
-    <string name="scan_downloads_added">Añadido</string>
-    <string name="scan_downloads_added_message">%1$s añadido</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Biblioteca nativa</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Mods externos</string>
-    <string name="external_mods_subtitle">Mods de la comunidad para Minecraft %1$s</string>
-    <string name="external_mods_no_version">Selecciona una versión de Minecraft antes de instalar mods</string>
-    <string name="external_mods_search_hint">Buscar mods, autores o versiones…</string>
-    <string name="external_mods_compatible_only">Solo compatibles</string>
-    <string name="external_mods_all_versions">Todas las versiones de Minecraft</string>
-    <string name="external_mods_sort_newest">Más recientes</string>
-    <string name="external_mods_sort_name">Nombre A–Z</string>
-    <string name="external_mods_empty">Ningún mod coincide con estos filtros</string>
-    <string name="external_mods_load_failed">No se pudo actualizar el catálogo. Se muestra la copia guardada.</string>
-    <string name="external_mods_refresh">Actualizar catálogo</string>
-    <string name="external_mods_refreshed">Catálogo actualizado</string>
-    <string name="external_mods_join_discord">Unirse al Discord de la comunidad</string>
-    <string name="external_mods_discord_open_failed">Ninguna aplicación puede abrir la invitación de Discord</string>
-    <string name="external_mods_download">Descargando %1$s</string>
-    <string name="external_mods_importing">Importando mod…</string>
-    <string name="external_mods_installed">%1$s instalado</string>
-    <string name="external_mods_install_failed">No se pudo instalar %1$s: %2$s</string>
-    <string name="external_mods_open_failed">Ningún navegador puede abrir esta descarga</string>
-    <string name="external_mods_direct_download">Descarga directa</string>
-    <string name="external_mods_ad_download">Descarga con anuncios</string>
-    <string name="external_mods_external_link">Enlace externo</string>
-    <string name="external_mods_open_link">Abrir enlace</string>
-    <string name="external_mods_external_dialog_title">Descarga externa</string>
-    <string name="external_mods_ad_dialog_title">Descarga con anuncios</string>
-    <string name="external_mods_external_dialog_message">%1$s usa una página de descarga fuera de LeviLauncher.\n\n1. Toca Abrir enlace y descarga el archivo .levipack o .so.\n2. Vuelve a LeviLauncher y abre Mods.\n3. Toca Escanear.\n4. Toca Añadir junto al mod que quieras importar.\n\nEl escaneo solo revisa la carpeta principal de Descargas. Mueve el archivo allí si tu navegador lo guardó en otro lugar.</string>
-    <string name="external_mods_ad_dialog_message">%1$s usa una página de descarga con anuncios elegida por su desarrollador. LeviLauncher no controla esa página ni sus anuncios.\n\n1. Toca Abrir enlace y descarga el archivo .levipack o .so.\n2. Vuelve a LeviLauncher y abre Mods.\n3. Toca Escanear.\n4. Toca Añadir junto al mod que quieras importar.\n\nEl escaneo solo revisa la carpeta principal de Descargas. Descarga únicamente el archivo del mod; no instales aplicaciones no relacionadas ni permitas notificaciones.</string>
-    <string name="external_mods_by_author">por %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Actualizar</string>
-    <string name="external_mods_installed_button">Instalado</string>
-    <string name="external_mods_incompatible">Incompatible</string>
-    <string name="foreground_service">Servicio en primer plano</string>
-    <string name="foreground_service_desc">Mantén Minecraft en ejecución al cambiar de aplicación evitando que Bedrock suspenda la sesión activa y manteniendo activos el proceso, la CPU y el Wi-Fi.</string>
-    <string name="foreground_service_warning">Nota: Puede hacer que tu teléfono se caliente más rápido y aumentar el consumo de batería.</string>
-    <string name="foreground_service_channel">Protección de Minecraft en segundo plano</string>
-    <string name="foreground_service_notification_title">Minecraft se mantiene activo</string>
-    <string name="foreground_service_notification_text">El modo en segundo plano de Minecraft está activo. La CPU y el acceso a la red se mantienen disponibles para la sesión actual.</string>
-    <string name="mod_menu_compact">Menú de mods compacto</string>
-    <string name="mod_menu_compact_desc">Usa un menú más pequeño con una lista de módulos densa y filtros compactos</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicador de sensibilidad (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Velocidad horizontal (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Velocidad vertical (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Filtro de movimientos pequeños (0 = Desactivado)</string>
-    <string name="hud_editor_drag_hint">Arrastra para mover el panel</string>
-    <string name="hud_editor_drag_description">Editor de HUD. Arrastra esta zona para mover el panel.</string>
     <string name="mod_config_hotbar_item_icons">Usar iconos de objetos de la barra rápida</string>
     <string name="mod_config_hotbar_item_counts">Mostrar cantidad de objetos</string>
     <string name="mod_config_hotbar_slot_enabled">Mostrar ranura %1$d de la barra rápida</string>
     <string name="mod_config_hotbar_slot_size">Tamaño de la ranura %1$d de la barra rápida (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Opacidad de la ranura %1$d de la barra rápida</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Novedades</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Continuar</string>
@@ -1069,6 +1114,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="mod_config_category_button">Botón</string>
     <string name="mod_config_visible_slots">Ranuras visibles</string>
     <string name="mod_config_hotbar_slot_section">Ranura %1$d de la barra rápida</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Seleccionar</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="selected">Seleccionado</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Para instalar o actualizar esta app, concede permiso para instalar apps desconocidas. Toca \"Conceder\" para abrir los ajustes del sistema, habilitar el permiso para esta app y volver para continuar.</string>
 
     <string name="check_update">Buscar actualizaciones</string>
-    <string name="version_prefix">Versión:</string>
+    <string name="version_prefix">Versión: </string>
     <string name="unknown_error">Error desconocido</string>
     <string name="preloader_sigs_title">Datos de tiempo de ejecución</string>
     <string name="preloader_sigs_last_update">Última actualización: %1$s</string>
@@ -452,7 +452,7 @@ La migración debe completarse antes de continuar con LeviLauncher.</string>
     <string name="genuine_badge_label">Licencia no verificada</string>
     <string name="invalid_license_detected_toast">Minecraft no original detectado. Asegúrate de tener Minecraft de Google Play Store</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Total de Mods:</string>
     <string name="enabled_mods">Habilitados:</string>
     <string name="add_mod">Añadir Mod</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -69,6 +76,7 @@
     <string name="files_processed">%d fichiers mod traités avec succès</string>
     <string name="user_cancelled">Importation annulée par l\'utilisateur</string>
 
+
     <string name="exit">Quitter</string>
 
     <string name="overlay_permission_message">Veuillez accorder l\'autorisation de superposition</string>
@@ -103,11 +111,12 @@
     <string name="settings_tab_migration">Migration</string>
     <string name="settings_theme_desc">Choisir le thème de l\'application</string>
 
+
     <string name="unknown_sources_permission_title">Autorisation d\'installation</string>
     <string name="unknown_sources_permission_message">Pour installer ou mettre à jour cette application, veuillez accorder l\'autorisation d\'installer des applications inconnues.</string>
 
     <string name="check_update">Vérifier les mises à jour</string>
-    <string name="version_prefix">Version : </string>
+    <string name="version_prefix">Version :</string>
     <string name="unknown_error">Erreur inconnue</string>
     <string name="preloader_sigs_title">Données d’exécution</string>
     <string name="preloader_sigs_last_update">Dernière mise à jour : %1$s</string>
@@ -131,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">Vous essayez de lancer une version installée avec l\'isolation de version activée. Veuillez désactiver l\'isolation de version pour continuer.</string>
     <string name="dialog_positive_disable">Désactiver</string>
     <string name="dialog_positive_ok">OK</string>
+    <string name="delete_account_title">Supprimer le compte</string>
+    <string name="delete_account_confirm">Voulez-vous vraiment supprimer ce compte ?</string>
+
 
     <string name="new_version_found">Nouvelle version trouvée : %1$s</string>
     <string name="update_question">Voulez-vous télécharger et installer la dernière version ?</string>
@@ -158,6 +170,7 @@
     <string name="repair_preparing">Préparation…</string>
     <string name="repair_processing">Extraction des bibliothèques…</string>
     <string name="repair_finalizing">Finalisation de la réparation…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Migration du stockage requise</string>
     <string name="storage_migration_message">LeviLauncher doit migrer les données de games/org.levimc vers %1$s avant de continuer.
 
@@ -202,21 +215,21 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="shared_storage_layout_mode_legacy">Répertoires internes/externes d\'origine</string>
     <string name="shared_storage_layout_status">Mode actuel : %1$s\nInterne : %2$s\nExterne : %3$s</string>
     <string name="shared_storage_layout_changed">La sélection du répertoire de stockage a été mise à jour. Redémarrez Minecraft et rouvrez la gestion du contenu pour appliquer complètement le changement.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Mode Thème</string>
     <string name="theme_follow_system">Suivre le système</string>
     <string name="theme_light">Mode Clair</string>
     <string name="theme_dark">Mode Sombre</string>
 
     <string name="error_no_browser">Aucun navigateur disponible</string>
-
+    <!-- License & Security -->
     <string name="eula_title">Accord de licence LeviLauncher</string>
     <string name="eula_message"><b>Bienvenue sur LeviLauncher</b>\n\nEn utilisant ce logiciel, vous acceptez :\n\n• C\'est un lanceur Minecraft <b>non officiel</b>\n• Vous devez posséder une copie <b>sous licence</b> de Minecraft\n• Toute forme de piratage ou de triche est interdite\n• Les mods/packs de ressources sont utilisés à vos risques et périls\n• Non affilié à Mojang/Microsoft\n\nL\'utilisation continue vaut acceptation</string>
     <string name="eula_agree">Accepter</string>
     <string name="eula_exit">Refuser</string>
 
     <string name="allow_unknown_sources">Veuillez autoriser l\'installation à partir de sources inconnues avant de continuer</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Supprimer la version</string>
     <string name="dialog_message_delete_version">Êtes-vous sûr de vouloir supprimer cette version personnalisée ? Cette action ne peut pas être annulée.</string>
     <string name="dialog_positive_delete">Supprimer</string>
@@ -236,7 +249,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="version_isolation">Isolation de version</string>
     <string name="launch_vertically">Lancement vertical</string>
     <string name="launch_vertically_desc">Forcer le jeu à se lancer en mode portrait</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Paramètres d\'instance</string>
     <string name="instance_tab_general">Général</string>
     <string name="instance_tab_launch_options">Options de lancement</string>
@@ -247,12 +260,32 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="instance_clear_icon">Effacer</string>
     <string name="instance_icon_hint">Sera enregistré sous LargeLogo.png dans le dossier de version. Cliquez sur l\'icône pour changer.</string>
     <string name="instance_isolation_desc">Isoler les données de jeu pour cette instance. Les autres ne seront pas affectées.</string>
+    <string name="instance_shortcut_title">Raccourci sur l’écran d’accueil</string>
+    <string name="instance_shortcut_desc">Les modifications du nom et de l’icône sont enregistrées automatiquement. Appuyez sur Ajouter un raccourci pour créer ou mettre à jour le raccourci de l’écran d’accueil.</string>
+    <string name="instance_shortcut_name">Nom du raccourci</string>
+    <string name="instance_shortcut_icon">Icône du raccourci</string>
+    <string name="instance_shortcut_choose_icon">Choisir une icône</string>
+    <string name="instance_shortcut_default_icon">Utiliser l’icône par défaut</string>
+    <string name="instance_shortcut_add_button">Ajouter un raccourci</string>
+    <string name="instance_settings_auto_save_failed">Impossible d’enregistrer ce paramètre de l’instance.</string>
+    <string name="instance_shortcut_not_supported">Votre lanceur d’écran d’accueil ne prend pas en charge les raccourcis épinglés.</string>
+    <string name="instance_shortcut_missing">Cette instance de Minecraft n’est plus disponible.</string>
     <string name="instance_danger_zone">Zone de danger</string>
     <string name="instance_danger_zone_desc">Ces actions affectent l\'enregistrement de l\'instance ou les fichiers locaux. Vérifiez bien.</string>
     <string name="instance_delete_desc">Supprime définitivement cette instance de votre appareil (mondes, configurations, etc.).</string>
     <string name="instance_delete_warning">Cette action ne peut pas être annulée.</string>
     <string name="instance_delete_confirm_title">Supprimer l\'instance</string>
     <string name="instance_delete_confirm_msg">Êtes-vous sûr ? Toutes les données, y compris les mondes, seront définitivement supprimées.</string>
+    <string name="instance_backup_title">Sauvegarder l\'instance</string>
+    <string name="instance_backup_desc">Crée une sauvegarde complète de cette instance dans Download/LeviLauncher/Backups.</string>
+    <string name="instance_backup_button">Sauvegarder l\'instance</string>
+    <string name="instance_backup_confirm_message">Créer maintenant une sauvegarde complète de cette instance ? Quittez d\'abord Minecraft s\'il est en cours d\'exécution afin d\'éviter toute modification de fichiers pendant la sauvegarde.</string>
+    <string name="instance_backup_in_progress">Sauvegarde de l\'instance…</string>
+    <string name="instance_backup_success_title">Sauvegarde créée</string>
+    <string name="instance_backup_success_message">Sauvegarde enregistrée dans :\n%1$s</string>
+    <string name="instance_backup_failed_title">Échec de la sauvegarde</string>
+    <string name="instance_backup_failed_message">Impossible de créer la sauvegarde :\n%1$s</string>
+    <string name="instance_import_backup_button">Importer une sauvegarde</string>
     <string name="instance_batch_backup_button">Sauvegarde par lot</string>
     <string name="instance_batch_backup_title">Sauvegarde par lot des instances</string>
     <string name="instance_batch_backup_select_message">Sélectionnez les instances à sauvegarder. Quittez Minecraft s\'il est en cours d\'exécution afin d\'éviter toute modification des données pendant la sauvegarde.</string>
@@ -266,7 +299,16 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="instance_batch_backup_partial_message">%1$d sauvegardes créées, %2$d échecs.\n\nEnregistrées :\n%3$s\n\nÉchecs :\n%4$s</string>
     <string name="instance_batch_backup_failed_title">Échec de la sauvegarde par lot</string>
     <string name="instance_batch_backup_failed_message">Impossible de créer une sauvegarde :\n%1$s</string>
+    <string name="instance_restore_title">Restaurer la sauvegarde</string>
+    <string name="instance_restore_in_progress">Restauration de la sauvegarde de l\'instance…</string>
+    <string name="instance_restore_success_title">Restauration terminée</string>
+    <string name="instance_restore_success_message">Restauré : %1$s</string>
+    <string name="instance_restore_failed_title">Échec de la restauration</string>
+    <string name="instance_restore_failed_message">Impossible de restaurer la sauvegarde :\n%1$s</string>
 
+    <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Langue (Language)</string>
     <string name="english">Anglais (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -280,6 +322,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
+    <!-- Version Rename -->
     <string name="rename_version_title">Renommer la version</string>
     <string name="rename_version_message">Entrez un nouveau nom pour cette version :</string>
     <string name="new_version_name">Nouveau nom de version</string>
@@ -288,6 +331,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="rename_failed">Échec du renommage : %1$s</string>
     <string name="cannot_rename_installed">Impossible de renommer les versions installées</string>
 
+    <!-- Content Management -->
     <string name="content_management">Gestion de contenu</string>
     <string name="worlds_title">Mondes</string>
     <string name="resource_packs_title">Packs de ressources</string>
@@ -319,6 +363,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="import_failed">Échec de l\'importation</string>
     <string name="import_addon_success">Addon importé : %1$d packs de ressources, %2$d packs de comportements</string>
 
+    <!-- World Management -->
     <string name="world_size">Taille : %s</string>
     <string name="world_last_played">Dernière partie : %s</string>
     <string name="import_world">Importer un monde</string>
@@ -330,6 +375,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="delete">Supprimer</string>
     <string name="delete_pack">Supprimer</string>
 
+    <!-- Resource Pack Management -->
     <string name="import_resource_pack">Importer un pack de ressources</string>
     <string name="import_behavior_pack">Importer un pack de comportements</string>
     <string name="import_skin_pack">Importer un pack de skins</string>
@@ -337,6 +383,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="delete_skin_pack">Supprimer le pack de skins</string>
     <string name="delete_behavior_pack">Supprimer le pack de comportements</string>
 
+    <!-- Content Operations -->
     <string name="confirm_delete_world">Voulez-vous vraiment supprimer ce monde ? Cette action est irréversible.</string>
     <string name="confirm_delete_resource_pack">Voulez-vous vraiment supprimer ce pack ? Cette action est irréversible.</string>
     <string name="confirm_delete_behavior_pack">Voulez-vous vraiment supprimer ce pack ? Cette action est irréversible.</string>
@@ -351,9 +398,11 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="deleting_screenshot">Suppression de la capture d\'écran…</string>
     <string name="deleting_server">Suppression du serveur…</string>
 
+    <!-- World Editor -->
     <string name="edit_world">Éditer le monde</string>
     <string name="edit">Éditer</string>
     <string name="save">Enregistrer</string>
+    <string name="reset">Réinitialiser</string>
     <string name="saved_to_gallery">Enregistré dans la galerie</string>
     <string name="level_dat_not_found">level.dat introuvable</string>
     <string name="no_editable_properties">Aucune propriété modifiable trouvée</string>
@@ -365,6 +414,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="discard_changes_message">Vous avez des modifications non enregistrées. Voulez-vous les annuler ?</string>
     <string name="discard">Annuler</string>
 
+    <!-- Custom Flat World -->
     <string name="custom_flat_world">Monde plat personnalisé</string>
     <string name="world_name">Nom du monde</string>
     <string name="enter_world_name">Entrez le nom du monde</string>
@@ -377,7 +427,22 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="add_at_least_one_layer">Ajoutez au moins une couche</string>
     <string name="world_created_successfully">Monde créé avec succès</string>
     <string name="failed_to_create_world">Échec de la création du monde</string>
+    <string name="custom_flat_world_subtitle">Créez un monde avec votre propre biome et vos propres couches de blocs</string>
+    <string name="world_settings">Paramètres du monde</string>
+    <string name="world_settings_hint">Choisissez les paramètres de base du nouveau monde</string>
+    <string name="layers_title">Couches</string>
+    <string name="add_layer_compact">Ajouter une couche</string>
+    <string name="no_layers_title">Aucune couche pour l’instant</string>
+    <string name="no_layers_hint">Ajoutez au moins une couche de blocs pour créer le monde</string>
+    <string name="reorder_layer">Réorganiser la couche</string>
+    <string name="delete_layer">Supprimer la couche</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d couche • bas → haut</item>
+        <item quantity="other">%1$d couches • bas → haut</item>
+    </plurals>
 
+    <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Version Play Store requise</string>
     <string name="minecraft_playstore_required_message">Ce lanceur fonctionne uniquement avec l\'application officielle Minecraft du Google Play Store.</string>
     <string name="buy_minecraft">Obtenir Minecraft</string>
@@ -387,11 +452,59 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="genuine_badge_label">Licence non vérifiée</string>
     <string name="invalid_license_detected_toast">Minecraft non officiel détecté. Assurez-vous d\'avoir la version du Play Store.</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Total des mods :</string>
     <string name="enabled_mods">Activés :</string>
     <string name="add_mod">Ajouter un Mod</string>
+    <string name="scan_downloads">Analyser</string>
+    <string name="scan_downloads_scanning">Analyse…</string>
+    <string name="scan_downloads_none_found">Aucun mod .levipack ou .so trouvé dans Téléchargements</string>
+    <string name="scan_downloads_failed">Impossible d’analyser Téléchargements</string>
+    <string name="scan_downloads_permission_denied">L’accès au stockage est nécessaire pour analyser Téléchargements</string>
+    <string name="scan_downloads_results_title">Mods dans Téléchargements</string>
+    <string name="scan_downloads_results_subtitle">Choisissez un mod à ajouter. L’analyse vérifie uniquement le dossier Téléchargements principal.</string>
+    <string name="scan_downloads_add">Ajouter</string>
+    <string name="scan_downloads_adding">Ajout…</string>
+    <string name="scan_downloads_added">Ajouté</string>
+    <string name="scan_downloads_added_message">%1$s ajouté</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Bibliothèque native</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Mods externes</string>
+    <string name="external_mods_subtitle">Mods de la communauté pour Minecraft %1$s</string>
+    <string name="external_mods_no_version">Sélectionnez une version de Minecraft avant d’installer des mods</string>
+    <string name="external_mods_search_hint">Rechercher des mods, auteurs ou versions…</string>
+    <string name="external_mods_compatible_only">Compatibles uniquement</string>
+    <string name="external_mods_all_versions">Toutes les versions de Minecraft</string>
+    <string name="external_mods_sort_newest">Plus récents</string>
+    <string name="external_mods_sort_name">Nom A–Z</string>
+    <string name="external_mods_empty">Aucun mod ne correspond à ces filtres</string>
+    <string name="external_mods_load_failed">Impossible d’actualiser le catalogue. La copie enregistrée est affichée.</string>
+    <string name="external_mods_refresh">Actualiser le catalogue</string>
+    <string name="external_mods_refreshed">Catalogue actualisé</string>
+    <string name="external_mods_join_discord">Rejoindre le Discord de la communauté</string>
+    <string name="external_mods_discord_open_failed">Aucune application ne peut ouvrir l’invitation Discord</string>
+    <string name="external_mods_download">Téléchargement de %1$s</string>
+    <string name="external_mods_importing">Importation du mod…</string>
+    <string name="external_mods_installed">%1$s installé</string>
+    <string name="external_mods_install_failed">Impossible d’installer %1$s : %2$s</string>
+    <string name="external_mods_open_failed">Aucun navigateur ne peut ouvrir ce téléchargement</string>
+    <string name="external_mods_direct_download">Téléchargement direct</string>
+    <string name="external_mods_ad_download">Téléchargement avec publicité</string>
+    <string name="external_mods_external_link">Lien externe</string>
+    <string name="external_mods_open_link">Ouvrir le lien</string>
+    <string name="external_mods_external_dialog_title">Téléchargement externe</string>
+    <string name="external_mods_ad_dialog_title">Téléchargement financé par la publicité</string>
+    <string name="external_mods_external_dialog_message">%1$s utilise une page de téléchargement en dehors de LeviLauncher.\n\n1. Appuyez sur Ouvrir le lien et téléchargez le fichier .levipack ou .so.\n2. Revenez dans LeviLauncher et ouvrez Mods.\n3. Appuyez sur Analyser.\n4. Appuyez sur Ajouter à côté du mod que vous souhaitez importer.\n\nL’analyse vérifie uniquement le dossier Téléchargements principal. Déplacez-y le fichier si votre navigateur l’a enregistré ailleurs.</string>
+    <string name="external_mods_ad_dialog_message">%1$s utilise une page de téléchargement avec publicité choisie par son développeur. LeviLauncher ne contrôle ni cette page ni ses publicités.\n\n1. Appuyez sur Ouvrir le lien et téléchargez le fichier .levipack ou .so.\n2. Revenez dans LeviLauncher et ouvrez Mods.\n3. Appuyez sur Analyser.\n4. Appuyez sur Ajouter à côté du mod que vous souhaitez importer.\n\nL’analyse vérifie uniquement le dossier Téléchargements principal. Téléchargez uniquement le fichier du mod ; n’installez aucune application sans rapport et n’autorisez pas les notifications.</string>
+    <string name="external_mods_by_author">par %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Mettre à jour</string>
+    <string name="external_mods_installed_button">Installé</string>
+    <string name="external_mods_incompatible">Incompatible</string>
 
+    <!-- Mod Detail -->
     <string name="mod_detail_title">Détails du Mod</string>
     <string name="delete_mod">Supprimer le Mod</string>
     <string name="error_loading_mod">Erreur de chargement du mod</string>
@@ -399,10 +512,63 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="mod_disabled">Mod désactivé</string>
     <string name="mod_filename_format">Fichier : %s</string>
     <string name="mod_enable_status">État d\'activation</string>
+    <string name="mod_icon_content_description">Icône du mod</string>
+    <string name="mod_author_byline">par %s</string>
+    <string name="mod_version_chip">Version %s</string>
+    <string name="mod_metadata_title">Informations</string>
+    <string name="mod_actions_title">Actions</string>
+    <string name="mod_author_label">Auteur</string>
+    <string name="mod_version_label">Version</string>
+    <string name="mod_minecraft_versions_label">Versions de Minecraft</string>
+    <string name="mod_entry_label">Fichier d\'entrée</string>
+    <string name="mod_id_label">ID du mod</string>
+    <string name="mod_config_files_label">Fichiers de configuration</string>
+    <string name="mod_unknown_author">Auteur inconnu</string>
+    <string name="mod_unknown_version">Version inconnue</string>
+    <string name="mod_all_versions">Toutes les versions prises en charge</string>
+    <string name="mod_no_config_files">Aucune configuration modifiable</string>
+    <string name="mod_config_badge">CONFIG</string>
+    <string name="mod_config_badge_with_count">CONFIG · %d</string>
+    <string name="mod_config_title_format">Configuration de %s</string>
+    <string name="mod_config_not_found">Aucune configuration modifiable trouvée</string>
+    <string name="mod_config_load_failed">Échec du chargement de la configuration : %s</string>
+    <string name="mod_config_save_failed">Échec de l\'enregistrement de la configuration</string>
+    <string name="mod_config_saved">Configuration enregistrée</string>
+    <string name="mod_config_restart_hint">Le fichier de configuration a été enregistré et un fichier .backup a été conservé.</string>
+    <string name="mod_config_validation_failed">Échec de la validation de la configuration</string>
+    <string name="mod_config_invalid_json">JSON invalide</string>
+    <string name="mod_config_expand">Développer</string>
+    <string name="mod_config_collapse">Réduire</string>
+    <string name="mod_config_raw_json">Modifier le JSON brut</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">Élément %1$s</string>
+    <string name="mod_config_object_desc">Groupe de paramètres liés</string>
+    <string name="mod_config_array_desc">Liste de valeurs</string>
+    <string name="mod_config_range_prefix">Plage</string>
+    <string name="mod_config_error_number">%1$s doit être un nombre</string>
+    <string name="mod_config_error_minimum">%1$s doit être au moins %2$s</string>
+    <string name="mod_config_error_maximum">%1$s doit être au plus %2$s</string>
+    <string name="mod_config_error_boolean">%1$s doit être activé ou désactivé</string>
+    <string name="mod_config_error_string">%1$s doit être du texte</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d configuration modifiable</item>
+        <item quantity="other">%d configurations modifiables</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d choix</item>
+        <item quantity="other">%d choix</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d élément</item>
+        <item quantity="other">%d éléments</item>
+    </plurals>
 
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">Sélectionner la version du jeu</string>
     <string name="back">Retour</string>
 
+    <!-- Splash -->
     <string name="splash_logo_desc">Logo de la feuille</string>
     <string name="minecraft_loading_title">Lancement de Minecraft</string>
     <string name="minecraft_loading_subtitle">Preparation des bibliotheques natives et des mods actives</string>
@@ -416,6 +582,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="launcher_restart_subtitle">Un instant, vous allez revenir à l\'accueil</string>
     <string name="launcher_restart_status">Presque terminé…</string>
 
+    <!-- Accounts & Microsoft Login -->
     <string name="accounts_title">Comptes</string>
     <string name="microsoft_accounts">Comptes Microsoft</string>
     <string name="manage_accounts">Gérer les comptes</string>
@@ -426,13 +593,45 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="accounts_active_privilege">Connecté</string>
 
     <string name="ms_login_title">Connexion Microsoft</string>
+    <string name="ms_login_header_subtitle">Connectez-vous à Minecraft en toute sécurité</string>
     <string name="ms_login_starting">Démarrage de la connexion Microsoft…</string>
     <string name="ms_login_exchanging">Échange de jeton…</string>
     <string name="ms_login_auth_xbox_device">Authentification de l\'appareil Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Récupération de l\'identité Minecraft…</string>
+    <string name="ms_login_retrying">Connexion interrompue. Nouvelle tentative sécurisée…</string>
     <string name="ms_login_success">Connecté en tant que %1$s</string>
     <string name="ms_login_failed">Échec de la connexion Microsoft</string>
     <string name="ms_login_failed_detail">Échec de la connexion : %1$s</string>
+    <string name="ms_choose_login_method">Se connecter à Minecraft</string>
+    <string name="ms_choose_login_method_desc">Choisissez le flux de code d\'appareil via le navigateur ou continuez avec la page Microsoft intégrée.</string>
+    <string name="ms_device_code_login">Continuer avec le navigateur</string>
+    <string name="ms_device_code_option_title">Code d\'appareil (recommandé)</string>
+    <string name="ms_device_code_login_desc">Ouvrez une session privée du navigateur avec le code d\'appareil déjà rempli.</string>
+    <string name="ms_webview_login">Ouvrir la connexion intégrée</string>
+    <string name="ms_webview_option_title">WebView intégrée</string>
+    <string name="ms_webview_login_desc">Connectez-vous sans quitter LeviLauncher. Utilisez cette option lorsque le flux du navigateur n\'est pas disponible.</string>
+    <string name="ms_device_code_title">Se connecter avec un code d\'appareil</string>
+    <string name="ms_device_code_instructions">Ouvrez la page de connexion d\'appareil Microsoft, saisissez ce code, puis approuvez l\'accès. LeviLauncher terminera automatiquement.</string>
+    <string name="ms_device_code_label">Code d\'appareil Microsoft</string>
+    <string name="ms_device_code_requesting">Demande d\'un code sécurisé…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">En attente de la fin dans votre navigateur…</string>
+    <string name="ms_device_code_checking">Vérification du résultat de la connexion Microsoft…</string>
+    <string name="ms_device_code_reconnecting">La connexion a changé. Nouvelle tentative automatique…</string>
+    <string name="ms_device_code_authorized">Microsoft a approuvé la connexion. Finalisation…</string>
+    <string name="ms_device_code_browser_opened">Terminez la nouvelle connexion Microsoft dans votre navigateur, puis revenez ici.</string>
+    <string name="ms_device_code_expires">Le code expire dans %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Copier le code</string>
+    <string name="ms_device_code_copied">Code copié</string>
+    <string name="ms_device_code_open_browser">Ouvrir la connexion Microsoft</string>
+    <string name="ms_device_code_step_title">Terminez la connexion dans votre navigateur</string>
+    <string name="ms_device_code_browser_note">LeviLauncher ouvre votre navigateur par défaut dans une session privée, remplit automatiquement le code et demande une nouvelle connexion Microsoft.</string>
+    <string name="ms_choose_other_method">Autre méthode</string>
+    <string name="ms_no_browser">Aucun navigateur n\'est disponible sur cet appareil.</string>
+    <string name="ms_default_browser_no_private_mode">Votre navigateur par défaut ne prend pas en charge la connexion privée. Mettez-le à jour ou utilisez la connexion WebView.</string>
+    <string name="ms_login_ssl_failed">La page sécurisée de connexion Microsoft n\'a pas pu être vérifiée.</string>
+    <string name="ms_login_state_failed">La réponse de connexion Microsoft n\'a pas pu être vérifiée. Recommencez la connexion.</string>
+    <string name="ms_login_missing_code">Microsoft n\'a pas renvoyé de code de connexion. Recommencez la connexion ou utilisez le code d\'appareil.</string>
 
     <string name="ms_set_active">Définir comme actif</string>
     <string name="ms_delete">Supprimer</string>
@@ -445,9 +644,14 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="go_to_accounts">Comptes</string>
     <string name="disable_launcher_login_and_continue">Fermer</string>
 
+    <string name="ms_feature_disabled_title">Fonction désactivée</string>
+    <string name="ms_feature_disabled_desc">Activez « Se connecter à Minecraft avec LeviLauncher » dans les paramètres pour gérer les comptes Microsoft.</string>
+    <string name="ms_activated">Activé</string>
+
+    <!-- Popup labels -->
     <string name="label_current_account">Compte actuel</string>
     <string name="label_other_accounts">Autres comptes</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">L\'application s\'est arrêtée</string>
     <string name="crash_upload">Téléverser le rapport de plantage</string>
     <string name="crash_details_title">Détails du plantage</string>
@@ -466,8 +670,15 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="dialog_message_exit_app">Êtes-vous sûr de vouloir quitter ?</string>
     <string name="dialog_positive_exit">Quitter</string>
     <string name="show_logcat_overlay">Superposition Logcat</string>
+    <string name="foreground_service">Service au premier plan</string>
+    <string name="foreground_service_desc">Maintient Minecraft en fonctionnement lorsque vous changez d’application en empêchant Bedrock de suspendre la session active et en gardant le processus, le processeur et le Wi-Fi actifs.</string>
+    <string name="foreground_service_warning">Remarque : peut faire chauffer votre téléphone plus rapidement et augmenter la consommation de batterie.</string>
+    <string name="foreground_service_channel">Protection de Minecraft en arrière-plan</string>
+    <string name="foreground_service_notification_title">Minecraft est maintenu actif</string>
+    <string name="foreground_service_notification_text">Le mode arrière-plan de Minecraft est actif. Le processeur et l’accès au réseau restent disponibles pour la session en cours.</string>
     <string name="logcat_live">Logcat : <b>en direct</b></string>
     <string name="logcat_paused">Logcat : en pause</string>
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">Filtre par mot-clé</string>
     <string name="logcat_blacklist_hint">Liste noire (séparée par virgules)</string>
     <string name="logcat_filter_clear">Effacer les filtres</string>
@@ -479,6 +690,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="logcat_corner_bottom_left">Redimensionner : bas-gauche</string>
     <string name="logcat_corner_bottom_right">Redimensionner : bas-droite</string>
 
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mods">Mods intégrés</string>
     <string name="inbuilt_mods_title">Mods intégrés</string>
     <string name="inbuilt_mods_subtitle">Mods internes sans bibliothèques natives</string>
@@ -487,7 +699,8 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="inbuilt_mod_removed">%s supprimé des mods</string>
     <string name="add">Ajouter</string>
     <string name="remove">Supprimer</string>
-
+    
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">Dépôt Rapide</string>
     <string name="inbuilt_mod_quick_drop_desc">Déposer des objets rapidement</string>
     <string name="inbuilt_mod_camera">Perspective rapide</string>
@@ -515,16 +728,25 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="virtual_cursor_enabled">Curseur activé</string>
     <string name="virtual_cursor_disabled">Curseur désactivé</string>
     <string name="cursor_sensitivity_label">Sensibilité du curseur :</string>
+    <string name="inbuilt_mod_gyro">Gyroscope</string>
+    <string name="inbuilt_mod_gyro_desc">Utilise le gyroscope de l\'appareil pour contrôler la rotation de la caméra</string>
+    <string name="inbuilt_mod_pojav_controls">Contrôles Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Remplace les commandes tactiles de Minecraft par des commandes de style Pojav entièrement personnalisables</string>
+    <string name="inbuilt_mod_more_buttons">Plus de boutons</string>
+    <string name="inbuilt_mod_more_buttons_desc">Créez des boutons personnalisés à l\'écran avec une seule touche assignée et des icônes SVG</string>
     <string name="inbuilt_badge">INTÉGRÉ</string>
     <string name="autosprint_keybind_label">Touche Sprint Auto :</string>
     <string name="autosprint_keybind_press">Appuyez sur une touche…</string>
     <string name="configure">Configurer</string>
     <string name="overlay_button_size">Taille du bouton superposé</string>
     <string name="overlay_button_opacity">Opacité du bouton</string>
+    <string name="overlay_button_size_value">Taille : %1$ddp</string>
+    <string name="overlay_button_opacity_value">Opacité : %1$d%%</string>
     <string name="overlay_button_lock">Verrouiller la position</string>
     <string name="overlay_button_lock_desc">Empêcher le glissement accidentel</string>
     <string name="settings">Paramètres</string>
 
+    <!-- Extract Structures -->
     <string name="extract_structures">Extraire des structures</string>
     <string name="no_structures_found">Aucune structure trouvée dans ce monde</string>
     <string name="no_structures_found_title">Aucune structure trouvée</string>
@@ -538,15 +760,36 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="structures_found_title">Structures trouvées</string>
     <string name="structures_found_count">%d structures trouvées dans ce monde</string>
 
+    <!-- Mod Menu -->
     <string name="mod_menu">Menu Mod</string>
     <string name="mod_menu_modules">Modules</string>
+    <string name="mod_menu_favorites">Favoris</string>
+    <string name="mod_menu_favorite">Ajouter aux favoris</string>
+    <string name="mod_menu_unfavorite">Retirer des favoris</string>
+    <string name="mod_menu_hud_editor">Éditeur HUD</string>
+    <string name="mod_menu_filter_enabled">Activés</string>
+    <string name="mod_menu_filter_inbuilt">Intégrés</string>
+    <string name="mod_menu_filter_external">Externes</string>
     <string name="mod_menu_search_hint">Rechercher des mods…</string>
     <string name="mod_menu_no_mods">Aucun mod ajouté</string>
+    <string name="mod_menu_no_favorites">Aucun mod favori pour le moment</string>
+    <string name="mod_menu_no_matches">Aucun mod correspondant</string>
+    <string name="mod_menu_group_inbuilt">Fonctionnalités intégrées</string>
+    <string name="mod_menu_group_external_ungrouped">Mods externes non groupés</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Paramètres généraux</string>
+    <string name="mod_menu_appearance">Apparence</string>
+    <string name="mod_menu_pause_menu_only">Menu pause uniquement</string>
+    <string name="mod_menu_pause_menu_only_desc">Afficher le menu des mods uniquement dans le menu de pause</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Paramètres à venir</string>
     <string name="mod_menu_notifications">Notifications</string>
     <string name="mod_menu_notifications_desc">Afficher une notification lors de l\'activation des mods</string>
     <string name="mod_menu_opacity">Opacité du menu de mods</string>
     <string name="mod_menu_button_opacity">Opacité du bouton menu</string>
+    <string name="mod_menu_compact">Menu des mods compact</string>
+    <string name="mod_menu_compact_desc">Utilisez un menu plus petit avec une liste de modules dense et des filtres compacts</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Menu Mod activé</string>
     <string name="mod_menu_disabled">Menu Mod désactivé</string>
@@ -555,7 +798,37 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="mod_status_enabled">Activé</string>
     <string name="mod_status_disabled">Désactivé</string>
     <string name="mod_notification_enabled">%s activé</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Taille du bouton de superposition (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacité de la superposition (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Afficher partout</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilité du curseur (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Niveau de zoom (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Touche de sprint automatique</string>
+    <string name="mod_config_zoom_keybind">Touche de zoom</string>
+    <string name="mod_config_zoom_transition">Durée de transition (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicateur de sensibilité (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Vitesse horizontale (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Vitesse verticale (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Filtre des petits mouvements (0 = Désactivé)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilité horizontale (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilité verticale (%)</string>
+    <string name="mod_config_gyro_invert_x">Inverser l\'axe horizontal</string>
+    <string name="mod_config_gyro_invert_y">Inverser l\'axe vertical</string>
+    <string name="mod_config_gyro_deadzone">Zone morte</string>
+    <string name="mod_config_press_any_key">Appuyez sur une touche pour associer...</string>
+    <string name="mod_config_key_unknown">INCONNU</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Faites glisser pour déplacer le panneau</string>
+    <string name="hud_editor_drag_description">Éditeur du HUD. Faites glisser cette zone pour déplacer le panneau.</string>
 
+    <!-- Options Editor -->
     <string name="edit_options">Modifier les options</string>
     <string name="options_file_not_found">Fichier d\'options introuvable</string>
     <string name="no_options_found">Aucune option trouvée</string>
@@ -564,6 +837,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="error_loading_options">Erreur de chargement des options</string>
     <string name="options_saved">Options enregistrées avec succès</string>
 
+    <!-- Quick Launch -->
     <string name="quick_launch_title">Lancement Rapide</string>
     <string name="quick_launch_subtitle">Lancer Minecraft avec des actions spécifiques via URI</string>
     <string name="quick_launch_how_to_play">Comment jouer</string>
@@ -591,6 +865,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="quick_launch_custom_uri">URI Personnalisée</string>
     <string name="quick_launch_custom_uri_desc">Entrez une URI minecraft:// personnalisée</string>
 
+    <!-- Quick Launch Dialogs -->
     <string name="server_ip_hint">Adresse IP du serveur</string>
     <string name="server_port_hint">Port (défaut : 19132)</string>
     <string name="server_name_hint">Nom du serveur</string>
@@ -602,6 +877,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="custom_uri_hint">Entrez une URI complète. Ex : \nminecraft://openStore\nminecraft://?showStoreOffer=UUID</string>
     <string name="select_tab">Sélectionner un onglet :</string>
 
+    <!-- Quick Launch Validation -->
     <string name="server_ip_required">L\'IP du serveur est requise</string>
     <string name="server_details_required">Nom et IP du serveur requis</string>
     <string name="invalid_port">Numéro de port invalide</string>
@@ -610,14 +886,17 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="command_required">Commande requise</string>
     <string name="invalid_minecraft_uri">URI minecraft:// invalide</string>
 
+    <!-- Quick Launch Actions -->
     <string name="connect">Connecter</string>
     <string name="join">Rejoindre</string>
     <string name="load">Charger</string>
     <string name="execute">Exécuter</string>
 
+    <!-- Quick Actions Menu -->
     <string name="quick_launch">Lancement Rapide</string>
     <string name="quick_launch_menu_subtitle">Lancer avec des actions URI</string>
 
+    <!-- CurseForge -->
     <string name="curseforge_title">CurseForge</string>
     <string name="curseforge_subtitle">Parcourir et télécharger des contenus</string>
     <string name="curseforge_search_hint">Rechercher des contenus…</string>
@@ -627,6 +906,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="curseforge_download_failed">Échec du téléchargement</string>
     <string name="curseforge_available_files">Fichiers disponibles</string>
 
+    <!-- Navigation Bar -->
     <string name="nav_launch">Lancer</string>
     <string name="nav_import">Importer</string>
     <string name="nav_instances">Instances</string>
@@ -673,7 +953,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
         <item>CurseForge vous permet de télécharger du contenu de la communauté directement.</item>
         <item>Chargez des modules natifs SO externes pour étendre ou améliorer les performances de Minecraft.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Couleur du thème</string>
     <string name="theme_color_desc">La couleur d\'accentuation principale</string>
     <string name="preset_colors">COULEURS PRÉDÉFINIES</string>
@@ -691,163 +971,8 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
 
     <string name="unsupported_version_title">Version non prise en charge</string>
     <string name="unsupported_version_msg">Ce lanceur ne prend pas en charge les versions de Minecraft antérieures à 1.21.80.</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">par %s</string>
-    <string name="mod_version_chip">Version %s</string>
-    <string name="mod_config_title_format">Configuration de %s</string>
-    <string name="mod_config_not_found">Aucune configuration modifiable trouvée</string>
-    <string name="mod_config_load_failed">Échec du chargement de la configuration : %s</string>
-    <string name="mod_config_save_failed">Échec de l\'enregistrement de la configuration</string>
-    <string name="mod_config_saved">Configuration enregistrée</string>
-    <string name="mod_config_restart_hint">Le fichier de configuration a été enregistré et un fichier .backup a été conservé.</string>
-    <string name="mod_config_validation_failed">Échec de la validation de la configuration</string>
-    <string name="mod_config_invalid_json">JSON invalide</string>
-    <string name="mod_config_expand">Développer</string>
-    <string name="mod_config_collapse">Réduire</string>
-    <string name="mod_config_raw_json">Modifier le JSON brut</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">Élément %1$s</string>
-    <string name="mod_config_object_desc">Groupe de paramètres liés</string>
-    <string name="mod_config_array_desc">Liste de valeurs</string>
-    <string name="mod_config_range_prefix">Plage</string>
-    <string name="mod_config_error_number">%1$s doit être un nombre</string>
-    <string name="mod_config_error_minimum">%1$s doit être au moins %2$s</string>
-    <string name="mod_config_error_maximum">%1$s doit être au plus %2$s</string>
-    <string name="mod_config_error_boolean">%1$s doit être activé ou désactivé</string>
-    <string name="mod_config_error_string">%1$s doit être du texte</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d configuration modifiable</item>
-        <item quantity="other">%d configurations modifiables</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d choix</item>
-        <item quantity="other">%d choix</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d élément</item>
-        <item quantity="other">%d éléments</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Favoris</string>
-    <string name="mod_menu_favorite">Ajouter aux favoris</string>
-    <string name="mod_menu_unfavorite">Retirer des favoris</string>
-    <string name="mod_menu_hud_editor">Éditeur HUD</string>
-    <string name="mod_menu_filter_enabled">Activés</string>
-    <string name="mod_menu_filter_inbuilt">Intégrés</string>
-    <string name="mod_menu_filter_external">Externes</string>
-    <string name="mod_menu_no_favorites">Aucun mod favori pour le moment</string>
-    <string name="mod_menu_no_matches">Aucun mod correspondant</string>
-    <string name="mod_menu_group_inbuilt">Fonctionnalités intégrées</string>
-    <string name="mod_menu_group_external_ungrouped">Mods externes non groupés</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Paramètres généraux</string>
-    <string name="mod_menu_appearance">Apparence</string>
-    <string name="mod_menu_pause_menu_only">Menu pause uniquement</string>
-    <string name="mod_menu_pause_menu_only_desc">Afficher le menu des mods uniquement dans le menu de pause</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Taille du bouton de superposition (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacité de la superposition (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilité du curseur (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Niveau de zoom (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Touche de sprint automatique</string>
-    <string name="mod_config_zoom_keybind">Touche de zoom</string>
-    <string name="mod_config_press_any_key">Appuyez sur une touche pour associer...</string>
-    <string name="mod_config_key_unknown">INCONNU</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Taille : %1$ddp</string>
-    <string name="overlay_button_opacity_value">Opacité : %1$d%%</string>
-    <string name="reset">Réinitialiser</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Supprimer le compte</string>
-    <string name="delete_account_confirm">Voulez-vous vraiment supprimer ce compte ?</string>
-    <string name="instance_backup_title">Sauvegarder l\'instance</string>
-    <string name="instance_backup_desc">Crée une sauvegarde complète de cette instance dans Download/LeviLauncher/Backups.</string>
-    <string name="instance_backup_button">Sauvegarder l\'instance</string>
-    <string name="instance_backup_confirm_message">Créer maintenant une sauvegarde complète de cette instance ? Quittez d\'abord Minecraft s\'il est en cours d\'exécution afin d\'éviter toute modification de fichiers pendant la sauvegarde.</string>
-    <string name="instance_backup_in_progress">Sauvegarde de l\'instance…</string>
-    <string name="instance_backup_success_title">Sauvegarde créée</string>
-    <string name="instance_backup_success_message">Sauvegarde enregistrée dans :\n%1$s</string>
-    <string name="instance_backup_failed_title">Échec de la sauvegarde</string>
-    <string name="instance_backup_failed_message">Impossible de créer la sauvegarde :\n%1$s</string>
-    <string name="instance_import_backup_button">Importer une sauvegarde</string>
-    <string name="instance_restore_title">Restaurer la sauvegarde</string>
-    <string name="instance_restore_in_progress">Restauration de la sauvegarde de l\'instance…</string>
-    <string name="instance_restore_success_title">Restauration terminée</string>
-    <string name="instance_restore_success_message">Restauré : %1$s</string>
-    <string name="instance_restore_failed_title">Échec de la restauration</string>
-    <string name="instance_restore_failed_message">Impossible de restaurer la sauvegarde :\n%1$s</string>
-    <string name="mod_icon_content_description">Icône du mod</string>
-    <string name="mod_metadata_title">Informations</string>
-    <string name="mod_actions_title">Actions</string>
-    <string name="mod_author_label">Auteur</string>
-    <string name="mod_version_label">Version</string>
-    <string name="mod_minecraft_versions_label">Versions de Minecraft</string>
-    <string name="mod_entry_label">Fichier d\'entrée</string>
-    <string name="mod_id_label">ID du mod</string>
-    <string name="mod_config_files_label">Fichiers de configuration</string>
-    <string name="mod_unknown_author">Auteur inconnu</string>
-    <string name="mod_unknown_version">Version inconnue</string>
-    <string name="mod_all_versions">Toutes les versions prises en charge</string>
-    <string name="mod_no_config_files">Aucune configuration modifiable</string>
-    <string name="mod_config_badge">CONFIG</string>
-    <string name="mod_config_badge_with_count">CONFIG · %d</string>
-    <string name="ms_login_header_subtitle">Connectez-vous à Minecraft en toute sécurité</string>
-    <string name="ms_login_retrying">Connexion interrompue. Nouvelle tentative sécurisée…</string>
-    <string name="ms_choose_login_method">Se connecter à Minecraft</string>
-    <string name="ms_choose_login_method_desc">Choisissez le flux de code d\'appareil via le navigateur ou continuez avec la page Microsoft intégrée.</string>
-    <string name="ms_device_code_login">Continuer avec le navigateur</string>
-    <string name="ms_device_code_option_title">Code d\'appareil (recommandé)</string>
-    <string name="ms_device_code_login_desc">Ouvrez une session privée du navigateur avec le code d\'appareil déjà rempli.</string>
-    <string name="ms_webview_login">Ouvrir la connexion intégrée</string>
-    <string name="ms_webview_option_title">WebView intégrée</string>
-    <string name="ms_webview_login_desc">Connectez-vous sans quitter LeviLauncher. Utilisez cette option lorsque le flux du navigateur n\'est pas disponible.</string>
-    <string name="ms_device_code_title">Se connecter avec un code d\'appareil</string>
-    <string name="ms_device_code_instructions">Ouvrez la page de connexion d\'appareil Microsoft, saisissez ce code, puis approuvez l\'accès. LeviLauncher terminera automatiquement.</string>
-    <string name="ms_device_code_label">Code d\'appareil Microsoft</string>
-    <string name="ms_device_code_requesting">Demande d\'un code sécurisé…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">En attente de la fin dans votre navigateur…</string>
-    <string name="ms_device_code_checking">Vérification du résultat de la connexion Microsoft…</string>
-    <string name="ms_device_code_reconnecting">La connexion a changé. Nouvelle tentative automatique…</string>
-    <string name="ms_device_code_authorized">Microsoft a approuvé la connexion. Finalisation…</string>
-    <string name="ms_device_code_browser_opened">Terminez la nouvelle connexion Microsoft dans votre navigateur, puis revenez ici.</string>
-    <string name="ms_device_code_expires">Le code expire dans %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Copier le code</string>
-    <string name="ms_device_code_copied">Code copié</string>
-    <string name="ms_device_code_open_browser">Ouvrir la connexion Microsoft</string>
-    <string name="ms_device_code_step_title">Terminez la connexion dans votre navigateur</string>
-    <string name="ms_device_code_browser_note">LeviLauncher ouvre votre navigateur par défaut dans une session privée, remplit automatiquement le code et demande une nouvelle connexion Microsoft.</string>
-    <string name="ms_choose_other_method">Autre méthode</string>
-    <string name="ms_no_browser">Aucun navigateur n\'est disponible sur cet appareil.</string>
-    <string name="ms_default_browser_no_private_mode">Votre navigateur par défaut ne prend pas en charge la connexion privée. Mettez-le à jour ou utilisez la connexion WebView.</string>
-    <string name="ms_login_ssl_failed">La page sécurisée de connexion Microsoft n\'a pas pu être vérifiée.</string>
-    <string name="ms_login_state_failed">La réponse de connexion Microsoft n\'a pas pu être vérifiée. Recommencez la connexion.</string>
-    <string name="ms_login_missing_code">Microsoft n\'a pas renvoyé de code de connexion. Recommencez la connexion ou utilisez le code d\'appareil.</string>
-    <string name="ms_feature_disabled_title">Fonction désactivée</string>
-    <string name="ms_feature_disabled_desc">Activez « Se connecter à Minecraft avec LeviLauncher » dans les paramètres pour gérer les comptes Microsoft.</string>
-    <string name="ms_activated">Activé</string>
-    <string name="inbuilt_mod_gyro">Gyroscope</string>
-    <string name="inbuilt_mod_gyro_desc">Utilise le gyroscope de l\'appareil pour contrôler la rotation de la caméra</string>
-    <string name="inbuilt_mod_pojav_controls">Contrôles Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Remplace les commandes tactiles de Minecraft par des commandes de style Pojav entièrement personnalisables</string>
-    <string name="inbuilt_mod_more_buttons">Plus de boutons</string>
-    <string name="inbuilt_mod_more_buttons_desc">Créez des boutons personnalisés à l\'écran avec une seule touche assignée et des icônes SVG</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Afficher partout</string>
-    <string name="mod_config_zoom_transition">Durée de transition (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilité horizontale (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilité verticale (%)</string>
-    <string name="mod_config_gyro_invert_x">Inverser l\'axe horizontal</string>
-    <string name="mod_config_gyro_invert_y">Inverser l\'axe vertical</string>
-    <string name="mod_config_gyro_deadzone">Zone morte</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Fermer</string>
     <string name="previous">Précédent</string>
     <string name="next">Suivant</string>
@@ -897,6 +1022,8 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="custom_color_hint">#RRGGBB ou R,G,B</string>
     <string name="screenshot_name_placeholder">Nom de la capture d\'écran</string>
     <string name="screenshot_date_placeholder">Date : 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Créez des boutons à l\'écran de style Minecraft, chacun associé à exactement une touche du clavier. Les boutons n\'exécutent jamais de macros, de séquences de touches, de répétitions automatiques ni d\'autoclic.</string>
     <string name="more_buttons_add_button">Ajouter un bouton</string>
     <string name="more_buttons_limit_reached">La limite de %1$d boutons personnalisés est atteinte.</string>
@@ -954,99 +1081,17 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="more_buttons_no_svg_selected">Aucun SVG sélectionné</string>
     <string name="more_buttons_default_name">Bouton</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Emplacement de barre rapide</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Ajoute des boutons séparés de 1 à 9 pour sélectionner les emplacements de la barre rapide</string>
     <string name="hotbar_slot_content_description">Emplacement de barre rapide %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Raccourci sur l’écran d’accueil</string>
-    <string name="instance_shortcut_desc">Les modifications du nom et de l’icône sont enregistrées automatiquement. Appuyez sur Ajouter un raccourci pour créer ou mettre à jour le raccourci de l’écran d’accueil.</string>
-    <string name="instance_shortcut_name">Nom du raccourci</string>
-    <string name="instance_shortcut_icon">Icône du raccourci</string>
-    <string name="instance_shortcut_choose_icon">Choisir une icône</string>
-    <string name="instance_shortcut_default_icon">Utiliser l’icône par défaut</string>
-    <string name="instance_shortcut_add_button">Ajouter un raccourci</string>
-    <string name="instance_settings_auto_save_failed">Impossible d’enregistrer ce paramètre de l’instance.</string>
-    <string name="instance_shortcut_not_supported">Votre lanceur d’écran d’accueil ne prend pas en charge les raccourcis épinglés.</string>
-    <string name="instance_shortcut_missing">Cette instance de Minecraft n’est plus disponible.</string>
-    <string name="custom_flat_world_subtitle">Créez un monde avec votre propre biome et vos propres couches de blocs</string>
-    <string name="world_settings">Paramètres du monde</string>
-    <string name="world_settings_hint">Choisissez les paramètres de base du nouveau monde</string>
-    <string name="layers_title">Couches</string>
-    <string name="add_layer_compact">Ajouter une couche</string>
-    <string name="no_layers_title">Aucune couche pour l’instant</string>
-    <string name="no_layers_hint">Ajoutez au moins une couche de blocs pour créer le monde</string>
-    <string name="reorder_layer">Réorganiser la couche</string>
-    <string name="delete_layer">Supprimer la couche</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Analyser</string>
-    <string name="scan_downloads_scanning">Analyse…</string>
-    <string name="scan_downloads_none_found">Aucun mod .levipack ou .so trouvé dans Téléchargements</string>
-    <string name="scan_downloads_failed">Impossible d’analyser Téléchargements</string>
-    <string name="scan_downloads_permission_denied">L’accès au stockage est nécessaire pour analyser Téléchargements</string>
-    <string name="scan_downloads_results_title">Mods dans Téléchargements</string>
-    <string name="scan_downloads_results_subtitle">Choisissez un mod à ajouter. L’analyse vérifie uniquement le dossier Téléchargements principal.</string>
-    <string name="scan_downloads_add">Ajouter</string>
-    <string name="scan_downloads_adding">Ajout…</string>
-    <string name="scan_downloads_added">Ajouté</string>
-    <string name="scan_downloads_added_message">%1$s ajouté</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Bibliothèque native</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Mods externes</string>
-    <string name="external_mods_subtitle">Mods de la communauté pour Minecraft %1$s</string>
-    <string name="external_mods_no_version">Sélectionnez une version de Minecraft avant d’installer des mods</string>
-    <string name="external_mods_search_hint">Rechercher des mods, auteurs ou versions…</string>
-    <string name="external_mods_compatible_only">Compatibles uniquement</string>
-    <string name="external_mods_all_versions">Toutes les versions de Minecraft</string>
-    <string name="external_mods_sort_newest">Plus récents</string>
-    <string name="external_mods_sort_name">Nom A–Z</string>
-    <string name="external_mods_empty">Aucun mod ne correspond à ces filtres</string>
-    <string name="external_mods_load_failed">Impossible d’actualiser le catalogue. La copie enregistrée est affichée.</string>
-    <string name="external_mods_refresh">Actualiser le catalogue</string>
-    <string name="external_mods_refreshed">Catalogue actualisé</string>
-    <string name="external_mods_join_discord">Rejoindre le Discord de la communauté</string>
-    <string name="external_mods_discord_open_failed">Aucune application ne peut ouvrir l’invitation Discord</string>
-    <string name="external_mods_download">Téléchargement de %1$s</string>
-    <string name="external_mods_importing">Importation du mod…</string>
-    <string name="external_mods_installed">%1$s installé</string>
-    <string name="external_mods_install_failed">Impossible d’installer %1$s : %2$s</string>
-    <string name="external_mods_open_failed">Aucun navigateur ne peut ouvrir ce téléchargement</string>
-    <string name="external_mods_direct_download">Téléchargement direct</string>
-    <string name="external_mods_ad_download">Téléchargement avec publicité</string>
-    <string name="external_mods_external_link">Lien externe</string>
-    <string name="external_mods_open_link">Ouvrir le lien</string>
-    <string name="external_mods_external_dialog_title">Téléchargement externe</string>
-    <string name="external_mods_ad_dialog_title">Téléchargement financé par la publicité</string>
-    <string name="external_mods_external_dialog_message">%1$s utilise une page de téléchargement en dehors de LeviLauncher.\n\n1. Appuyez sur Ouvrir le lien et téléchargez le fichier .levipack ou .so.\n2. Revenez dans LeviLauncher et ouvrez Mods.\n3. Appuyez sur Analyser.\n4. Appuyez sur Ajouter à côté du mod que vous souhaitez importer.\n\nL’analyse vérifie uniquement le dossier Téléchargements principal. Déplacez-y le fichier si votre navigateur l’a enregistré ailleurs.</string>
-    <string name="external_mods_ad_dialog_message">%1$s utilise une page de téléchargement avec publicité choisie par son développeur. LeviLauncher ne contrôle ni cette page ni ses publicités.\n\n1. Appuyez sur Ouvrir le lien et téléchargez le fichier .levipack ou .so.\n2. Revenez dans LeviLauncher et ouvrez Mods.\n3. Appuyez sur Analyser.\n4. Appuyez sur Ajouter à côté du mod que vous souhaitez importer.\n\nL’analyse vérifie uniquement le dossier Téléchargements principal. Téléchargez uniquement le fichier du mod ; n’installez aucune application sans rapport et n’autorisez pas les notifications.</string>
-    <string name="external_mods_by_author">par %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Mettre à jour</string>
-    <string name="external_mods_installed_button">Installé</string>
-    <string name="external_mods_incompatible">Incompatible</string>
-    <string name="foreground_service">Service au premier plan</string>
-    <string name="foreground_service_desc">Maintient Minecraft en fonctionnement lorsque vous changez d’application en empêchant Bedrock de suspendre la session active et en gardant le processus, le processeur et le Wi-Fi actifs.</string>
-    <string name="foreground_service_warning">Remarque : peut faire chauffer votre téléphone plus rapidement et augmenter la consommation de batterie.</string>
-    <string name="foreground_service_channel">Protection de Minecraft en arrière-plan</string>
-    <string name="foreground_service_notification_title">Minecraft est maintenu actif</string>
-    <string name="foreground_service_notification_text">Le mode arrière-plan de Minecraft est actif. Le processeur et l’accès au réseau restent disponibles pour la session en cours.</string>
-    <string name="mod_menu_compact">Menu des mods compact</string>
-    <string name="mod_menu_compact_desc">Utilisez un menu plus petit avec une liste de modules dense et des filtres compacts</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicateur de sensibilité (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Vitesse horizontale (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Vitesse verticale (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Filtre des petits mouvements (0 = Désactivé)</string>
-    <string name="hud_editor_drag_hint">Faites glisser pour déplacer le panneau</string>
-    <string name="hud_editor_drag_description">Éditeur du HUD. Faites glisser cette zone pour déplacer le panneau.</string>
     <string name="mod_config_hotbar_item_icons">Utiliser les icônes d’objets de la barre rapide</string>
     <string name="mod_config_hotbar_item_counts">Afficher le nombre d’objets</string>
     <string name="mod_config_hotbar_slot_enabled">Afficher l’emplacement %1$d de la barre rapide</string>
     <string name="mod_config_hotbar_slot_size">Taille de l’emplacement %1$d de la barre rapide (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Opacité de l’emplacement %1$d de la barre rapide</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Nouveautés</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Continuer</string>
@@ -1069,6 +1114,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="mod_config_category_button">Bouton</string>
     <string name="mod_config_visible_slots">Emplacements visibles</string>
     <string name="mod_config_hotbar_slot_section">Emplacement %1$d de la barre rapide</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Sélectionner</string>
     <string name="select_all">Tout sélectionner</string>
     <string name="selected">Sélectionné</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Pour installer ou mettre à jour cette application, veuillez accorder l\'autorisation d\'installer des applications inconnues.</string>
 
     <string name="check_update">Vérifier les mises à jour</string>
-    <string name="version_prefix">Version :</string>
+    <string name="version_prefix">Version : </string>
     <string name="unknown_error">Erreur inconnue</string>
     <string name="preloader_sigs_title">Données d’exécution</string>
     <string name="preloader_sigs_last_update">Dernière mise à jour : %1$s</string>
@@ -452,7 +452,7 @@ La migration doit être terminée avant de continuer avec LeviLauncher.</string>
     <string name="genuine_badge_label">Licence non vérifiée</string>
     <string name="invalid_license_detected_toast">Minecraft non officiel détecté. Assurez-vous d\'avoir la version du Play Store.</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Total des mods :</string>
     <string name="enabled_mods">Activés :</string>
     <string name="add_mod">Ajouter un Mod</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">इस ऐप को इंस्टॉल या अपडेट करने के लिए, कृपया अज्ञात ऐप्स इंस्टॉल करने की अनुमति दें। सिस्टम सेटिंग्स खोलने के लिए "अनुमति दें" पर क्लिक करें, इस ऐप के लिए अनुमति सक्षम करें और जारी रखने के लिए वापस आएं।</string>
 
     <string name="check_update">अपडेट्स के लिए जांचें</string>
-    <string name="version_prefix">संस्करण:</string>
+    <string name="version_prefix">संस्करण: </string>
     <string name="unknown_error">अज्ञात त्रुटि</string>
     <string name="preloader_sigs_title">रनटाइम डेटा</string>
     <string name="preloader_sigs_last_update">अंतिम अपडेट: %1$s</string>
@@ -452,7 +452,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="genuine_badge_label">लाइसेंस सत्यापित नहीं है</string>
     <string name="invalid_license_detected_toast">गैर-वास्तविक Minecraft का पता चला। सुनिश्चित करें कि Minecraft Google Play Store से है</string>
 
-    <string name="full_mods_title">मॉड्स</string>
+    <string name="full_mods_title">मॉड्स </string>
     <string name="total_mods">कुल मॉड्स:</string>
     <string name="enabled_mods">सक्षम:</string>
     <string name="add_mod">मॉड जोड़ें</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -69,6 +76,7 @@
     <string name="files_processed">%d मॉड फ़ाइलों को सफलतापूर्वक संसाधित किया गया</string>
     <string name="user_cancelled">उपयोगकर्ता द्वारा आयात रद्द किया गया</string>
 
+
     <string name="exit">बाहर निकलें</string>
 
     <string name="overlay_permission_message">कृपया ओवरले अनुमति प्रदान करें</string>
@@ -103,11 +111,12 @@
     <string name="settings_tab_migration">माइग्रेशन</string>
     <string name="settings_theme_desc">एप्लिकेशन थीम चुनें</string>
 
+
     <string name="unknown_sources_permission_title">इंस्टॉल अनुमति</string>
     <string name="unknown_sources_permission_message">इस ऐप को इंस्टॉल या अपडेट करने के लिए, कृपया अज्ञात ऐप्स इंस्टॉल करने की अनुमति दें। सिस्टम सेटिंग्स खोलने के लिए "अनुमति दें" पर क्लिक करें, इस ऐप के लिए अनुमति सक्षम करें और जारी रखने के लिए वापस आएं।</string>
 
     <string name="check_update">अपडेट्स के लिए जांचें</string>
-    <string name="version_prefix">संस्करण: </string>
+    <string name="version_prefix">संस्करण:</string>
     <string name="unknown_error">अज्ञात त्रुटि</string>
     <string name="preloader_sigs_title">रनटाइम डेटा</string>
     <string name="preloader_sigs_last_update">अंतिम अपडेट: %1$s</string>
@@ -131,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">आप संस्करण आइसोलेशन सक्षम के साथ एक इंस्टॉल किया गया संस्करण लॉन्च करने का प्रयास कर रहे हैं। कृपया आगे बढ़ने के लिए संस्करण आइसोलेशन अक्षम करें।</string>
     <string name="dialog_positive_disable">अक्षम करें</string>
     <string name="dialog_positive_ok">ठीक है</string>
+    <string name="delete_account_title">खाता हटाएँ</string>
+    <string name="delete_account_confirm">क्या आप वाकई यह खाता हटाना चाहते हैं?</string>
+
 
     <string name="new_version_found">नया संस्करण मिला: %1$s</string>
     <string name="update_question">क्या आप नवीनतम संस्करण डाउनलोड और इंस्टॉल करना चाहते हैं?</string>
@@ -158,6 +170,7 @@
     <string name="repair_preparing">तैयारी हो रही है…</string>
     <string name="repair_processing">लाइब्रेरीज़ निकाली जा रही हैं…</string>
     <string name="repair_finalizing">मरम्मत पूरी की जा रही है…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">स्टोरेज माइग्रेशन आवश्यक है</string>
     <string name="storage_migration_message">LeviLauncher को जारी रखने से पहले games/org.levimc से डेटा %1$s में माइग्रेट करना होगा।
 
@@ -202,21 +215,21 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="shared_storage_layout_mode_legacy">मूल internal/external डायरेक्टरी</string>
     <string name="shared_storage_layout_status">वर्तमान मोड: %1$s\nInternal: %2$s\nExternal: %3$s</string>
     <string name="shared_storage_layout_changed">स्टोरेज डायरेक्टरी चयन अपडेट हो गया। बदलाव पूरी तरह लागू करने के लिए Minecraft को पुनः शुरू करें और content management फिर से खोलें।</string>
-
+    <!-- Theme -->
     <string name="theme_title">थीम मोड</string>
     <string name="theme_follow_system">सिस्टम का पालन करें</string>
     <string name="theme_light">लाइट मोड</string>
     <string name="theme_dark">डार्क मोड</string>
 
     <string name="error_no_browser">कोई ब्राउज़र उपलब्ध नहीं है</string>
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher लाइसेंस समझौता</string>
     <string name="eula_message"><b>LeviLauncher में आपका स्वागत है</b>\n\nइस सॉफ़्टवेयर का उपयोग करके आप सहमत हैं:\n\n• यह एक <b>अनौपचारिक</b> Minecraft लॉन्चर है\n• आपके पास Minecraft की एक <b>लाइसेंस प्राप्त</b> प्रति होनी चाहिए\n• किसी भी प्रकार की पायरेसी या धोखाधड़ी निषिद्ध है\n• मॉड्स/रिसोर्स पैक्स का उपयोग आपके अपने जोखिम पर है\n• Mojang/Microsoft से संबद्ध नहीं है\n\nनिरंतर उपयोग समझौते का गठन करता है</string>
     <string name="eula_agree">स्वीकार करें</string>
     <string name="eula_exit">अस्वीकार करें</string>
 
     <string name="allow_unknown_sources">कृपया आगे बढ़ने से पहले अज्ञात स्रोतों से इंस्टॉलेशन की अनुमति दें</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">संस्करण हटाएं</string>
     <string name="dialog_message_delete_version">क्या आप सुनिश्चित हैं कि आप इस कस्टम संस्करण को हटाना चाहते हैं? यह कार्रवाई पूर्ववत नहीं की जा सकती।</string>
     <string name="dialog_positive_delete">हटाएं</string>
@@ -236,7 +249,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="version_isolation">संस्करण आइसोलेशन</string>
     <string name="launch_vertically">लंबवत लॉन्च करें</string>
     <string name="launch_vertically_desc">गेम को पोर्ट्रेट मोड में लॉन्च करने के लिए बाध्य करें</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">इंस्टेंस सेटिंग्स</string>
     <string name="instance_tab_general">सामान्य</string>
     <string name="instance_tab_launch_options">लॉन्च विकल्प</string>
@@ -247,12 +260,32 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="instance_clear_icon">साफ़ करें</string>
     <string name="instance_icon_hint">संस्करण फ़ोल्डर के अंतर्गत LargeLogo.png के रूप में सहेजा जाएगा। बदलने के लिए आइकन पर क्लिक करें।</string>
     <string name="instance_isolation_desc">इस इंस्टेंस के लिए गेम डेटा को अलग करें। अन्य इंस्टेंस प्रभावित नहीं होंगे।</string>
+    <string name="instance_shortcut_title">होम स्क्रीन शॉर्टकट</string>
+    <string name="instance_shortcut_desc">नाम और आइकन में बदलाव अपने-आप सेव हो जाते हैं। होम स्क्रीन शॉर्टकट बनाने या अपडेट करने के लिए शॉर्टकट जोड़ें पर टैप करें।</string>
+    <string name="instance_shortcut_name">शॉर्टकट का नाम</string>
+    <string name="instance_shortcut_icon">शॉर्टकट आइकन</string>
+    <string name="instance_shortcut_choose_icon">आइकन चुनें</string>
+    <string name="instance_shortcut_default_icon">डिफ़ॉल्ट इस्तेमाल करें</string>
+    <string name="instance_shortcut_add_button">शॉर्टकट जोड़ें</string>
+    <string name="instance_settings_auto_save_failed">इस इंस्टेंस की सेटिंग सेव नहीं की जा सकी।</string>
+    <string name="instance_shortcut_not_supported">आपका होम स्क्रीन लॉन्चर पिन किए गए शॉर्टकट का समर्थन नहीं करता।</string>
+    <string name="instance_shortcut_missing">यह Minecraft इंस्टेंस अब उपलब्ध नहीं है।</string>
     <string name="instance_danger_zone">खतरा क्षेत्र</string>
     <string name="instance_danger_zone_desc">ये कार्य इंस्टेंस पंजीकरण या स्थानीय फ़ाइलों को प्रभावित करते हैं। जारी रखने से पहले दोबारा जांच लें।</string>
     <string name="instance_delete_desc">वर्ल्ड्स, कॉन्फिग्स और इंस्टॉल की गई सामग्री सहित, इस इंस्टेंस को आपके डिवाइस से स्थायी रूप से हटा देता है।</string>
     <string name="instance_delete_warning">यह कार्रवाई पूर्ववत नहीं की जा सकती।</string>
     <string name="instance_delete_confirm_title">इंस्टेंस हटाएं</string>
     <string name="instance_delete_confirm_msg">क्या आप सुनिश्चित हैं कि आप इस इंस्टेंस को हटाना चाहते हैं? वर्ल्ड्स सहित सभी डेटा स्थायी रूप से हटा दिया जाएगा।</string>
+    <string name="instance_backup_title">इंस्टेंस बैकअप</string>
+    <string name="instance_backup_desc">इस इंस्टेंस का पूरा बैकअप Download/LeviLauncher/Backups में बनाएँ।</string>
+    <string name="instance_backup_button">इंस्टेंस का बैकअप लें</string>
+    <string name="instance_backup_confirm_message">क्या अभी इस इंस्टेंस का पूरा बैकअप बनाना है? यदि Minecraft चल रहा है तो पहले उसे बंद करें, ताकि बैकअप के दौरान फ़ाइलें न बदलें।</string>
+    <string name="instance_backup_in_progress">इंस्टेंस का बैकअप लिया जा रहा है…</string>
+    <string name="instance_backup_success_title">बैकअप बनाया गया</string>
+    <string name="instance_backup_success_message">बैकअप यहाँ सहेजा गया:\n%1$s</string>
+    <string name="instance_backup_failed_title">बैकअप विफल</string>
+    <string name="instance_backup_failed_message">बैकअप नहीं बनाया जा सका:\n%1$s</string>
+    <string name="instance_import_backup_button">बैकअप आयात करें</string>
     <string name="instance_batch_backup_button">बैच बैकअप</string>
     <string name="instance_batch_backup_title">इंस्टेंस का बैच बैकअप</string>
     <string name="instance_batch_backup_select_message">बैकअप करने के लिए इंस्टेंस चुनें। यदि Minecraft चल रहा है, तो बैकअप के दौरान डेटा बदलने से बचने के लिए पहले उसे बंद करें।</string>
@@ -266,8 +299,16 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="instance_batch_backup_partial_message">%1$d बैकअप बनाए गए, %2$d विफल रहे।\n\nसहेजे गए:\n%3$s\n\nविफल:\n%4$s</string>
     <string name="instance_batch_backup_failed_title">बैच बैकअप विफल</string>
     <string name="instance_batch_backup_failed_message">कोई बैकअप नहीं बनाया जा सका:\n%1$s</string>
+    <string name="instance_restore_title">बैकअप पुनर्स्थापित करें</string>
+    <string name="instance_restore_in_progress">इंस्टेंस बैकअप पुनर्स्थापित किया जा रहा है…</string>
+    <string name="instance_restore_success_title">पुनर्स्थापना पूरी हुई</string>
+    <string name="instance_restore_success_message">पुनर्स्थापित: %1$s</string>
+    <string name="instance_restore_failed_title">पुनर्स्थापना विफल</string>
+    <string name="instance_restore_failed_message">बैकअप पुनर्स्थापित नहीं किया जा सका:\n%1$s</string>
 
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">भाषा (Language)</string>
     <string name="english">अंग्रेज़ी (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -361,6 +402,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="edit_world">वर्ल्ड संपादित करें</string>
     <string name="edit">संपादित करें</string>
     <string name="save">सहेजें</string>
+    <string name="reset">रीसेट</string>
     <string name="saved_to_gallery">गैलरी में सहेजा गया</string>
     <string name="level_dat_not_found">level.dat नहीं मिला</string>
     <string name="no_editable_properties">कोई संपादन योग्य गुण नहीं मिला</string>
@@ -385,6 +427,20 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="add_at_least_one_layer">कम से कम एक परत जोड़ें</string>
     <string name="world_created_successfully">वर्ल्ड सफलतापूर्वक बनाया गया</string>
     <string name="failed_to_create_world">वर्ल्ड बनाने में विफल</string>
+    <string name="custom_flat_world_subtitle">अपने बायोम और ब्लॉक लेयर्स के साथ दुनिया बनाएँ</string>
+    <string name="world_settings">दुनिया की सेटिंग</string>
+    <string name="world_settings_hint">नई दुनिया के लिए मूल सेटिंग चुनें</string>
+    <string name="layers_title">लेयर्स</string>
+    <string name="add_layer_compact">लेयर जोड़ें</string>
+    <string name="no_layers_title">अभी कोई लेयर नहीं</string>
+    <string name="no_layers_hint">दुनिया बनाने के लिए कम से कम एक ब्लॉक लेयर जोड़ें</string>
+    <string name="reorder_layer">लेयर का क्रम बदलें</string>
+    <string name="delete_layer">लेयर हटाएँ</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d परत • नीचे → ऊपर</item>
+        <item quantity="other">%1$d परतें • नीचे → ऊपर</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Play Store संस्करण आवश्यक है</string>
@@ -396,10 +452,57 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="genuine_badge_label">लाइसेंस सत्यापित नहीं है</string>
     <string name="invalid_license_detected_toast">गैर-वास्तविक Minecraft का पता चला। सुनिश्चित करें कि Minecraft Google Play Store से है</string>
 
-    <string name="full_mods_title">मॉड्स </string>
+    <string name="full_mods_title">मॉड्स</string>
     <string name="total_mods">कुल मॉड्स:</string>
     <string name="enabled_mods">सक्षम:</string>
     <string name="add_mod">मॉड जोड़ें</string>
+    <string name="scan_downloads">स्कैन करें</string>
+    <string name="scan_downloads_scanning">स्कैन हो रहा है…</string>
+    <string name="scan_downloads_none_found">Downloads में कोई .levipack या .so मॉड नहीं मिला</string>
+    <string name="scan_downloads_failed">Downloads को स्कैन नहीं किया जा सका</string>
+    <string name="scan_downloads_permission_denied">Downloads को स्कैन करने के लिए स्टोरेज एक्सेस चाहिए</string>
+    <string name="scan_downloads_results_title">Downloads में मॉड</string>
+    <string name="scan_downloads_results_subtitle">जोड़ने के लिए कोई मॉड चुनें। स्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है।</string>
+    <string name="scan_downloads_add">जोड़ें</string>
+    <string name="scan_downloads_adding">जोड़ा जा रहा है…</string>
+    <string name="scan_downloads_added">जोड़ दिया गया</string>
+    <string name="scan_downloads_added_message">%1$s जोड़ दिया गया</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">नेटिव लाइब्रेरी</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">बाहरी मॉड</string>
+    <string name="external_mods_subtitle">Minecraft %1$s के लिए कम्युनिटी मॉड</string>
+    <string name="external_mods_no_version">मॉड इंस्टॉल करने से पहले Minecraft का संस्करण चुनें</string>
+    <string name="external_mods_search_hint">मॉड, लेखक या संस्करण खोजें…</string>
+    <string name="external_mods_compatible_only">केवल संगत</string>
+    <string name="external_mods_all_versions">Minecraft के सभी संस्करण</string>
+    <string name="external_mods_sort_newest">सबसे नए</string>
+    <string name="external_mods_sort_name">नाम A–Z</string>
+    <string name="external_mods_empty">इन फ़िल्टर से कोई मॉड मेल नहीं खाता</string>
+    <string name="external_mods_load_failed">कैटलॉग रीफ़्रेश नहीं हो सका। सेव की गई कॉपी दिखाई जा रही है।</string>
+    <string name="external_mods_refresh">कैटलॉग रीफ़्रेश करें</string>
+    <string name="external_mods_refreshed">कैटलॉग रीफ़्रेश हो गया</string>
+    <string name="external_mods_join_discord">कम्युनिटी Discord से जुड़ें</string>
+    <string name="external_mods_discord_open_failed">कोई ऐप Discord आमंत्रण नहीं खोल सकता</string>
+    <string name="external_mods_download">%1$s डाउनलोड हो रहा है</string>
+    <string name="external_mods_importing">मॉड इम्पोर्ट हो रहा है…</string>
+    <string name="external_mods_installed">%1$s इंस्टॉल हो गया</string>
+    <string name="external_mods_install_failed">%1$s इंस्टॉल नहीं हो सका: %2$s</string>
+    <string name="external_mods_open_failed">कोई ब्राउज़र इस डाउनलोड को नहीं खोल सकता</string>
+    <string name="external_mods_direct_download">सीधा डाउनलोड</string>
+    <string name="external_mods_ad_download">विज्ञापन वाला डाउनलोड</string>
+    <string name="external_mods_external_link">बाहरी लिंक</string>
+    <string name="external_mods_open_link">लिंक खोलें</string>
+    <string name="external_mods_external_dialog_title">बाहरी डाउनलोड</string>
+    <string name="external_mods_ad_dialog_title">विज्ञापन-समर्थित डाउनलोड</string>
+    <string name="external_mods_external_dialog_message">%1$s LeviLauncher के बाहर की डाउनलोड वेबसाइट का उपयोग करता है।\n\n1. लिंक खोलें पर टैप करें और .levipack या .so फ़ाइल डाउनलोड करें।\n2. LeviLauncher पर वापस जाएँ और Mods खोलें।\n3. स्कैन करें पर टैप करें।\n4. जिस मॉड को इम्पोर्ट करना चाहते हैं, उसके पास जोड़ें पर टैप करें।\n\nस्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है। अगर ब्राउज़र ने फ़ाइल कहीं और सेव की है, तो उसे इस फ़ोल्डर में ले जाएँ।</string>
+    <string name="external_mods_ad_dialog_message">%1$s अपने डेवलपर द्वारा चुनी गई विज्ञापन-समर्थित डाउनलोड वेबसाइट का उपयोग करता है। LeviLauncher उस वेबसाइट या उसके विज्ञापनों को नियंत्रित नहीं करता।\n\n1. लिंक खोलें पर टैप करें और .levipack या .so फ़ाइल डाउनलोड करें।\n2. LeviLauncher पर वापस जाएँ और Mods खोलें।\n3. स्कैन करें पर टैप करें।\n4. जिस मॉड को इम्पोर्ट करना चाहते हैं, उसके पास जोड़ें पर टैप करें।\n\nस्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है। केवल मॉड फ़ाइल डाउनलोड करें; असंबंधित ऐप इंस्टॉल न करें और नोटिफिकेशन की अनुमति न दें।</string>
+    <string name="external_mods_by_author">%1$s द्वारा</string>
+    <string name="external_mods_version">मॉड %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">अपडेट करें</string>
+    <string name="external_mods_installed_button">इंस्टॉल किया गया</string>
+    <string name="external_mods_incompatible">असंगत</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">मॉड विवरण</string>
@@ -409,6 +512,57 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="mod_disabled">मॉड अक्षम</string>
     <string name="mod_filename_format">फ़ाइल: %s</string>
     <string name="mod_enable_status">सक्षम स्थिति</string>
+    <string name="mod_icon_content_description">मॉड आइकन</string>
+    <string name="mod_author_byline">%s द्वारा</string>
+    <string name="mod_version_chip">संस्करण %s</string>
+    <string name="mod_metadata_title">जानकारी</string>
+    <string name="mod_actions_title">क्रियाएँ</string>
+    <string name="mod_author_label">लेखक</string>
+    <string name="mod_version_label">संस्करण</string>
+    <string name="mod_minecraft_versions_label">Minecraft संस्करण</string>
+    <string name="mod_entry_label">एंट्री फ़ाइल</string>
+    <string name="mod_id_label">मॉड ID</string>
+    <string name="mod_config_files_label">कॉन्फ़िग फ़ाइलें</string>
+    <string name="mod_unknown_author">अज्ञात लेखक</string>
+    <string name="mod_unknown_version">अज्ञात संस्करण</string>
+    <string name="mod_all_versions">सभी समर्थित संस्करण</string>
+    <string name="mod_no_config_files">कोई संपादन योग्य कॉन्फ़िग नहीं</string>
+    <string name="mod_config_badge">कॉन्फ़िग</string>
+    <string name="mod_config_badge_with_count">कॉन्फ़िग · %d</string>
+    <string name="mod_config_title_format">%s कॉन्फ़िग</string>
+    <string name="mod_config_not_found">संपादन योग्य कॉन्फ़िग नहीं मिला</string>
+    <string name="mod_config_load_failed">कॉन्फ़िग लोड करने में विफल: %s</string>
+    <string name="mod_config_save_failed">कॉन्फ़िग सहेजने में विफल</string>
+    <string name="mod_config_saved">कॉन्फ़िग सहेजा गया</string>
+    <string name="mod_config_restart_hint">कॉन्फ़िग फ़ाइल सहेजी गई और .backup फ़ाइल रखी गई।</string>
+    <string name="mod_config_validation_failed">कॉन्फ़िग सत्यापन विफल</string>
+    <string name="mod_config_invalid_json">अमान्य JSON</string>
+    <string name="mod_config_expand">फैलाएं</string>
+    <string name="mod_config_collapse">समेटें</string>
+    <string name="mod_config_raw_json">मूल JSON संपादित करें</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">आइटम %1$s</string>
+    <string name="mod_config_object_desc">संबंधित सेटिंग्स का समूह</string>
+    <string name="mod_config_array_desc">मानों की सूची</string>
+    <string name="mod_config_range_prefix">सीमा</string>
+    <string name="mod_config_error_number">%1$s एक संख्या होनी चाहिए</string>
+    <string name="mod_config_error_minimum">%1$s कम से कम %2$s होना चाहिए</string>
+    <string name="mod_config_error_maximum">%1$s अधिकतम %2$s होना चाहिए</string>
+    <string name="mod_config_error_boolean">%1$s चालू या बंद होना चाहिए</string>
+    <string name="mod_config_error_string">%1$s टेक्स्ट होना चाहिए</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d संपादन योग्य कॉन्फ़िग</item>
+        <item quantity="other">%d संपादन योग्य कॉन्फ़िग</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d विकल्प</item>
+        <item quantity="other">%d विकल्प</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d आइटम</item>
+        <item quantity="other">%d आइटम</item>
+    </plurals>
 
     <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">गेम संस्करण चुनें</string>
@@ -439,13 +593,45 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="accounts_active_privilege">साइन इन किया गया</string>
 
     <string name="ms_login_title">Microsoft लॉगिन</string>
+    <string name="ms_login_header_subtitle">Minecraft में सुरक्षित रूप से साइन इन करें</string>
     <string name="ms_login_starting">Microsoft लॉगिन शुरू हो रहा है…</string>
     <string name="ms_login_exchanging">टोकन एक्सचेंज हो रहा है…</string>
     <string name="ms_login_auth_xbox_device">Xbox डिवाइस को प्रमाणित किया जा रहा है…</string>
     <string name="ms_login_fetch_minecraft_identity">Minecraft पहचान प्राप्त की जा रही है…</string>
+    <string name="ms_login_retrying">कनेक्शन बाधित हुआ। सुरक्षित रूप से फिर प्रयास किया जा रहा है…</string>
     <string name="ms_login_success">%1$s के रूप में साइन इन किया गया</string>
     <string name="ms_login_failed">Microsoft लॉगिन विफल</string>
     <string name="ms_login_failed_detail">लॉगिन विफल: %1$s</string>
+    <string name="ms_choose_login_method">Minecraft में साइन इन करें</string>
+    <string name="ms_choose_login_method_desc">ब्राउज़र-आधारित डिवाइस कोड प्रक्रिया चुनें या एम्बेडेड Microsoft पेज के साथ जारी रखें।</string>
+    <string name="ms_device_code_login">ब्राउज़र के साथ जारी रखें</string>
+    <string name="ms_device_code_option_title">डिवाइस कोड (अनुशंसित)</string>
+    <string name="ms_device_code_login_desc">पहले से भरे डिवाइस कोड के साथ एक निजी ब्राउज़र सत्र खोलें।</string>
+    <string name="ms_webview_login">एम्बेडेड साइन-इन खोलें</string>
+    <string name="ms_webview_option_title">एम्बेडेड WebView</string>
+    <string name="ms_webview_login_desc">LeviLauncher छोड़े बिना साइन इन करें। जब ब्राउज़र प्रक्रिया उपलब्ध न हो तब इसका उपयोग करें।</string>
+    <string name="ms_device_code_title">डिवाइस कोड से साइन इन करें</string>
+    <string name="ms_device_code_instructions">Microsoft का डिवाइस साइन-इन पेज खोलें, यह कोड दर्ज करें और फिर एक्सेस स्वीकृत करें। LeviLauncher अपने-आप पूरा कर देगा।</string>
+    <string name="ms_device_code_label">Microsoft डिवाइस कोड</string>
+    <string name="ms_device_code_requesting">सुरक्षित कोड का अनुरोध किया जा रहा है…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">ब्राउज़र में आपके पूरा करने की प्रतीक्षा है…</string>
+    <string name="ms_device_code_checking">Microsoft साइन-इन परिणाम जाँचा जा रहा है…</string>
+    <string name="ms_device_code_reconnecting">कनेक्शन बदल गया। अपने-आप फिर प्रयास किया जा रहा है…</string>
+    <string name="ms_device_code_authorized">Microsoft ने साइन-इन स्वीकृत कर दिया। पूरा किया जा रहा है…</string>
+    <string name="ms_device_code_browser_opened">ब्राउज़र में नया Microsoft साइन-इन पूरा करें, फिर यहाँ वापस आएँ।</string>
+    <string name="ms_device_code_expires">कोड %1$d:%2$02d में समाप्त होगा</string>
+    <string name="ms_device_code_copy">कोड कॉपी करें</string>
+    <string name="ms_device_code_copied">कोड कॉपी किया गया</string>
+    <string name="ms_device_code_open_browser">Microsoft साइन-इन खोलें</string>
+    <string name="ms_device_code_step_title">अपने ब्राउज़र में साइन-इन पूरा करें</string>
+    <string name="ms_device_code_browser_note">LeviLauncher आपके डिफ़ॉल्ट ब्राउज़र को निजी सत्र में खोलता है, कोड अपने-आप भरता है और नया Microsoft साइन-इन अनुरोध करता है।</string>
+    <string name="ms_choose_other_method">अन्य तरीका</string>
+    <string name="ms_no_browser">इस डिवाइस पर कोई ब्राउज़र उपलब्ध नहीं है।</string>
+    <string name="ms_default_browser_no_private_mode">आपका डिफ़ॉल्ट ब्राउज़र निजी साइन-इन का समर्थन नहीं करता। इसे अपडेट करें या WebView लॉगिन का उपयोग करें।</string>
+    <string name="ms_login_ssl_failed">सुरक्षित Microsoft साइन-इन पेज सत्यापित नहीं किया जा सका।</string>
+    <string name="ms_login_state_failed">Microsoft साइन-इन प्रतिक्रिया सत्यापित नहीं की जा सकी। फिर से साइन-इन शुरू करें।</string>
+    <string name="ms_login_missing_code">Microsoft ने साइन-इन कोड नहीं दिया। फिर से साइन-इन शुरू करें या डिवाइस कोड लॉगिन का उपयोग करें।</string>
 
     <string name="ms_set_active">सक्रिय सेट करें</string>
     <string name="ms_delete">हटाएं</string>
@@ -458,10 +644,14 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="go_to_accounts">खाते</string>
     <string name="disable_launcher_login_and_continue">बंद करें</string>
 
+    <string name="ms_feature_disabled_title">सुविधा अक्षम है</string>
+    <string name="ms_feature_disabled_desc">Microsoft खाते प्रबंधित करने के लिए सेटिंग्स में “LeviLauncher के साथ Minecraft में साइन इन करें” सक्षम करें।</string>
+    <string name="ms_activated">सक्रिय</string>
+
     <!-- Popup labels -->
     <string name="label_current_account">वर्तमान खाता</string>
     <string name="label_other_accounts">अन्य खाते</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">एप्लिकेशन क्रैश हो गया</string>
     <string name="crash_upload">क्रैश रिपोर्ट अपलोड करें</string>
     <string name="crash_details_title">क्रैश विवरण</string>
@@ -480,6 +670,12 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="dialog_message_exit_app">क्या आप सुनिश्चित हैं कि आप बाहर निकलना चाहते हैं?</string>
     <string name="dialog_positive_exit">बाहर निकलें</string>
     <string name="show_logcat_overlay">Logcat ओवरले</string>
+    <string name="foreground_service">फ़ोरग्राउंड सेवा</string>
+    <string name="foreground_service_desc">ऐप बदलते समय Bedrock को सक्रिय सेशन सस्पेंड करने से रोककर और प्रोसेस, CPU तथा Wi-Fi को सक्रिय रखकर Minecraft को चलता रहने देता है।</string>
+    <string name="foreground_service_warning">नोट: इससे फ़ोन जल्दी गर्म हो सकता है और बैटरी की खपत बढ़ सकती है।</string>
+    <string name="foreground_service_channel">Minecraft बैकग्राउंड सुरक्षा</string>
+    <string name="foreground_service_notification_title">Minecraft को सक्रिय रखा जा रहा है</string>
+    <string name="foreground_service_notification_text">Minecraft का बैकग्राउंड मोड सक्रिय है। मौजूदा सेशन के लिए CPU और नेटवर्क एक्सेस उपलब्ध रखे जा रहे हैं।</string>
     <string name="logcat_live">Logcat: <b>लाइव</b></string>
     <string name="logcat_paused">Logcat: रुका हुआ है</string>
     <!-- Logcat Overlay i18n -->
@@ -503,7 +699,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="inbuilt_mod_removed">%s मॉड्स से हटाया गया</string>
     <string name="add">जोड़ें</string>
     <string name="remove">हटाएं</string>
-
+    
     <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">क्विक ड्रॉप</string>
     <string name="inbuilt_mod_quick_drop_desc">आइटम जल्दी से छोड़ें</string>
@@ -532,12 +728,20 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="virtual_cursor_enabled">कर्सर सक्षम</string>
     <string name="virtual_cursor_disabled">कर्सर अक्षम</string>
     <string name="cursor_sensitivity_label">कर्सर संवेदनशीलता:</string>
+    <string name="inbuilt_mod_gyro">जाइरोस्कोप</string>
+    <string name="inbuilt_mod_gyro_desc">कैमरा घुमाव नियंत्रित करने के लिए डिवाइस के जाइरोस्कोप का उपयोग करें</string>
+    <string name="inbuilt_mod_pojav_controls">Pojav नियंत्रण</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Minecraft टच नियंत्रणों को पूरी तरह अनुकूलन योग्य Pojav-शैली नियंत्रणों से बदलें</string>
+    <string name="inbuilt_mod_more_buttons">अधिक बटन</string>
+    <string name="inbuilt_mod_more_buttons_desc">एकल-कुंजी मैपिंग और SVG आइकन के साथ कस्टम ऑन-स्क्रीन बटन बनाएँ</string>
     <string name="inbuilt_badge">अंतर्निर्मित</string>
     <string name="autosprint_keybind_label">ऑटो स्प्रिंट कीबाइंड:</string>
     <string name="autosprint_keybind_press">कोई भी कुंजी दबाएं…</string>
     <string name="configure">कॉन्फ़िगर करें</string>
     <string name="overlay_button_size">ओवरले बटन का आकार</string>
     <string name="overlay_button_opacity">ओवरले बटन अस्पष्टता</string>
+    <string name="overlay_button_size_value">आकार: %1$ddp</string>
+    <string name="overlay_button_opacity_value">अपारदर्शिता: %1$d%%</string>
     <string name="overlay_button_lock">स्थिति लॉक करें</string>
     <string name="overlay_button_lock_desc">खींचने और आकस्मिक सक्रियण को रोकें</string>
     <string name="settings">सेटिंग्स</string>
@@ -559,13 +763,33 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <!-- Mod Menu -->
     <string name="mod_menu">मॉड मेनू</string>
     <string name="mod_menu_modules">मॉड्यूल</string>
+    <string name="mod_menu_favorites">पसंदीदा</string>
+    <string name="mod_menu_favorite">पसंदीदा में जोड़ें</string>
+    <string name="mod_menu_unfavorite">पसंदीदा से हटाएं</string>
+    <string name="mod_menu_hud_editor">HUD एडिटर</string>
+    <string name="mod_menu_filter_enabled">सक्षम</string>
+    <string name="mod_menu_filter_inbuilt">अंतर्निर्मित</string>
+    <string name="mod_menu_filter_external">बाहरी</string>
     <string name="mod_menu_search_hint">मॉड्स खोजें…</string>
     <string name="mod_menu_no_mods">कोई मॉड नहीं जोड़ा गया</string>
+    <string name="mod_menu_no_favorites">अभी कोई पसंदीदा मॉड नहीं</string>
+    <string name="mod_menu_no_matches">कोई मेल खाता मॉड नहीं</string>
+    <string name="mod_menu_group_inbuilt">अंतर्निहित सुविधाएँ</string>
+    <string name="mod_menu_group_external_ungrouped">असमूहीकृत बाहरी मॉड</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">सामान्य सेटिंग्स</string>
+    <string name="mod_menu_appearance">रूप-रंग</string>
+    <string name="mod_menu_pause_menu_only">केवल पॉज़ मेनू</string>
+    <string name="mod_menu_pause_menu_only_desc">मॉड मेनू केवल पॉज़ स्क्रीन में दिखाएं</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">सेटिंग्स जल्द ही आ रही हैं</string>
     <string name="mod_menu_notifications">सूचनाएं</string>
     <string name="mod_menu_notifications_desc">मॉड्स को सक्षम करते समय अधिसूचना दिखाएं</string>
     <string name="mod_menu_opacity">मॉड मेनू अस्पष्टता</string>
     <string name="mod_menu_button_opacity">मॉड मेनू बटन अस्पष्टता</string>
+    <string name="mod_menu_compact">कॉम्पैक्ट मॉड मेनू</string>
+    <string name="mod_menu_compact_desc">घनी मॉड्यूल सूची और कॉम्पैक्ट फ़िल्टर वाला छोटा मेनू इस्तेमाल करें</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">मॉड मेनू सक्षम</string>
     <string name="mod_menu_disabled">मॉड मेनू अक्षम</string>
@@ -574,6 +798,35 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="mod_status_enabled">सक्षम</string>
     <string name="mod_status_disabled">अक्षम</string>
     <string name="mod_notification_enabled">%s सक्षम</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">ओवरले बटन आकार (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">ओवरले अपारदर्शिता (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">हर जगह दिखाएँ</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">कर्सर संवेदनशीलता (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">ज़ूम स्तर (%)</string>
+    <string name="mod_config_auto_sprint_keybind">ऑटो स्प्रिंट कीबाइंड</string>
+    <string name="mod_config_zoom_keybind">ज़ूम कीबाइंड</string>
+    <string name="mod_config_zoom_transition">ट्रांज़िशन अवधि (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">संवेदनशीलता गुणक (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">क्षैतिज गति (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">ऊर्ध्वाधर गति (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">छोटी गति फ़िल्टर (0 = बंद)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">क्षैतिज संवेदनशीलता (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">ऊर्ध्वाधर संवेदनशीलता (%)</string>
+    <string name="mod_config_gyro_invert_x">क्षैतिज अक्ष उलटें</string>
+    <string name="mod_config_gyro_invert_y">ऊर्ध्वाधर अक्ष उलटें</string>
+    <string name="mod_config_gyro_deadzone">डेड ज़ोन</string>
+    <string name="mod_config_press_any_key">बाइंड करने के लिए कोई भी कुंजी दबाएं...</string>
+    <string name="mod_config_key_unknown">अज्ञात</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">पैनल को ले जाने के लिए खींचें</string>
+    <string name="hud_editor_drag_description">HUD एडिटर। पैनल को ले जाने के लिए इस क्षेत्र को खींचें।</string>
 
     <!-- Options Editor -->
     <string name="edit_options">विकल्प संपादित करें</string>
@@ -700,7 +953,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
         <item>CurseForge आपको सीधे सामुदायिक सामग्री ब्राउज़ और डाउनलोड करने देता है।</item>
         <item>Minecraft सुविधाओं और प्रदर्शन का विस्तार या वृद्धि करने के लिए बाहरी देशी SO मॉड्यूल लोड करें।</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">थीम रंग</string>
     <string name="theme_color_desc">एप्लिकेशन का प्राथमिक उच्चारण रंग</string>
     <string name="preset_colors">प्रीसेट रंग</string>
@@ -718,163 +971,8 @@ LeviLauncher जारी रखने से पहले माइग्रे
 
     <string name="unsupported_version_title">असमर्थित संस्करण</string>
     <string name="unsupported_version_msg">यह लॉन्चर 1.21.80 से पुराने Minecraft संस्करणों का समर्थन नहीं करता है।</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">%s द्वारा</string>
-    <string name="mod_version_chip">संस्करण %s</string>
-    <string name="mod_config_title_format">%s कॉन्फ़िग</string>
-    <string name="mod_config_not_found">संपादन योग्य कॉन्फ़िग नहीं मिला</string>
-    <string name="mod_config_load_failed">कॉन्फ़िग लोड करने में विफल: %s</string>
-    <string name="mod_config_save_failed">कॉन्फ़िग सहेजने में विफल</string>
-    <string name="mod_config_saved">कॉन्फ़िग सहेजा गया</string>
-    <string name="mod_config_restart_hint">कॉन्फ़िग फ़ाइल सहेजी गई और .backup फ़ाइल रखी गई।</string>
-    <string name="mod_config_validation_failed">कॉन्फ़िग सत्यापन विफल</string>
-    <string name="mod_config_invalid_json">अमान्य JSON</string>
-    <string name="mod_config_expand">फैलाएं</string>
-    <string name="mod_config_collapse">समेटें</string>
-    <string name="mod_config_raw_json">मूल JSON संपादित करें</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">आइटम %1$s</string>
-    <string name="mod_config_object_desc">संबंधित सेटिंग्स का समूह</string>
-    <string name="mod_config_array_desc">मानों की सूची</string>
-    <string name="mod_config_range_prefix">सीमा</string>
-    <string name="mod_config_error_number">%1$s एक संख्या होनी चाहिए</string>
-    <string name="mod_config_error_minimum">%1$s कम से कम %2$s होना चाहिए</string>
-    <string name="mod_config_error_maximum">%1$s अधिकतम %2$s होना चाहिए</string>
-    <string name="mod_config_error_boolean">%1$s चालू या बंद होना चाहिए</string>
-    <string name="mod_config_error_string">%1$s टेक्स्ट होना चाहिए</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d संपादन योग्य कॉन्फ़िग</item>
-        <item quantity="other">%d संपादन योग्य कॉन्फ़िग</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d विकल्प</item>
-        <item quantity="other">%d विकल्प</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d आइटम</item>
-        <item quantity="other">%d आइटम</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">पसंदीदा</string>
-    <string name="mod_menu_favorite">पसंदीदा में जोड़ें</string>
-    <string name="mod_menu_unfavorite">पसंदीदा से हटाएं</string>
-    <string name="mod_menu_hud_editor">HUD एडिटर</string>
-    <string name="mod_menu_filter_enabled">सक्षम</string>
-    <string name="mod_menu_filter_inbuilt">अंतर्निर्मित</string>
-    <string name="mod_menu_filter_external">बाहरी</string>
-    <string name="mod_menu_no_favorites">अभी कोई पसंदीदा मॉड नहीं</string>
-    <string name="mod_menu_no_matches">कोई मेल खाता मॉड नहीं</string>
-    <string name="mod_menu_group_inbuilt">अंतर्निहित सुविधाएँ</string>
-    <string name="mod_menu_group_external_ungrouped">असमूहीकृत बाहरी मॉड</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">सामान्य सेटिंग्स</string>
-    <string name="mod_menu_appearance">रूप-रंग</string>
-    <string name="mod_menu_pause_menu_only">केवल पॉज़ मेनू</string>
-    <string name="mod_menu_pause_menu_only_desc">मॉड मेनू केवल पॉज़ स्क्रीन में दिखाएं</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">ओवरले बटन आकार (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">ओवरले अपारदर्शिता (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">कर्सर संवेदनशीलता (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">ज़ूम स्तर (%)</string>
-    <string name="mod_config_auto_sprint_keybind">ऑटो स्प्रिंट कीबाइंड</string>
-    <string name="mod_config_zoom_keybind">ज़ूम कीबाइंड</string>
-    <string name="mod_config_press_any_key">बाइंड करने के लिए कोई भी कुंजी दबाएं...</string>
-    <string name="mod_config_key_unknown">अज्ञात</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">आकार: %1$ddp</string>
-    <string name="overlay_button_opacity_value">अपारदर्शिता: %1$d%%</string>
-    <string name="reset">रीसेट</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">खाता हटाएँ</string>
-    <string name="delete_account_confirm">क्या आप वाकई यह खाता हटाना चाहते हैं?</string>
-    <string name="instance_backup_title">इंस्टेंस बैकअप</string>
-    <string name="instance_backup_desc">इस इंस्टेंस का पूरा बैकअप Download/LeviLauncher/Backups में बनाएँ।</string>
-    <string name="instance_backup_button">इंस्टेंस का बैकअप लें</string>
-    <string name="instance_backup_confirm_message">क्या अभी इस इंस्टेंस का पूरा बैकअप बनाना है? यदि Minecraft चल रहा है तो पहले उसे बंद करें, ताकि बैकअप के दौरान फ़ाइलें न बदलें।</string>
-    <string name="instance_backup_in_progress">इंस्टेंस का बैकअप लिया जा रहा है…</string>
-    <string name="instance_backup_success_title">बैकअप बनाया गया</string>
-    <string name="instance_backup_success_message">बैकअप यहाँ सहेजा गया:\n%1$s</string>
-    <string name="instance_backup_failed_title">बैकअप विफल</string>
-    <string name="instance_backup_failed_message">बैकअप नहीं बनाया जा सका:\n%1$s</string>
-    <string name="instance_import_backup_button">बैकअप आयात करें</string>
-    <string name="instance_restore_title">बैकअप पुनर्स्थापित करें</string>
-    <string name="instance_restore_in_progress">इंस्टेंस बैकअप पुनर्स्थापित किया जा रहा है…</string>
-    <string name="instance_restore_success_title">पुनर्स्थापना पूरी हुई</string>
-    <string name="instance_restore_success_message">पुनर्स्थापित: %1$s</string>
-    <string name="instance_restore_failed_title">पुनर्स्थापना विफल</string>
-    <string name="instance_restore_failed_message">बैकअप पुनर्स्थापित नहीं किया जा सका:\n%1$s</string>
-    <string name="mod_icon_content_description">मॉड आइकन</string>
-    <string name="mod_metadata_title">जानकारी</string>
-    <string name="mod_actions_title">क्रियाएँ</string>
-    <string name="mod_author_label">लेखक</string>
-    <string name="mod_version_label">संस्करण</string>
-    <string name="mod_minecraft_versions_label">Minecraft संस्करण</string>
-    <string name="mod_entry_label">एंट्री फ़ाइल</string>
-    <string name="mod_id_label">मॉड ID</string>
-    <string name="mod_config_files_label">कॉन्फ़िग फ़ाइलें</string>
-    <string name="mod_unknown_author">अज्ञात लेखक</string>
-    <string name="mod_unknown_version">अज्ञात संस्करण</string>
-    <string name="mod_all_versions">सभी समर्थित संस्करण</string>
-    <string name="mod_no_config_files">कोई संपादन योग्य कॉन्फ़िग नहीं</string>
-    <string name="mod_config_badge">कॉन्फ़िग</string>
-    <string name="mod_config_badge_with_count">कॉन्फ़िग · %d</string>
-    <string name="ms_login_header_subtitle">Minecraft में सुरक्षित रूप से साइन इन करें</string>
-    <string name="ms_login_retrying">कनेक्शन बाधित हुआ। सुरक्षित रूप से फिर प्रयास किया जा रहा है…</string>
-    <string name="ms_choose_login_method">Minecraft में साइन इन करें</string>
-    <string name="ms_choose_login_method_desc">ब्राउज़र-आधारित डिवाइस कोड प्रक्रिया चुनें या एम्बेडेड Microsoft पेज के साथ जारी रखें।</string>
-    <string name="ms_device_code_login">ब्राउज़र के साथ जारी रखें</string>
-    <string name="ms_device_code_option_title">डिवाइस कोड (अनुशंसित)</string>
-    <string name="ms_device_code_login_desc">पहले से भरे डिवाइस कोड के साथ एक निजी ब्राउज़र सत्र खोलें।</string>
-    <string name="ms_webview_login">एम्बेडेड साइन-इन खोलें</string>
-    <string name="ms_webview_option_title">एम्बेडेड WebView</string>
-    <string name="ms_webview_login_desc">LeviLauncher छोड़े बिना साइन इन करें। जब ब्राउज़र प्रक्रिया उपलब्ध न हो तब इसका उपयोग करें।</string>
-    <string name="ms_device_code_title">डिवाइस कोड से साइन इन करें</string>
-    <string name="ms_device_code_instructions">Microsoft का डिवाइस साइन-इन पेज खोलें, यह कोड दर्ज करें और फिर एक्सेस स्वीकृत करें। LeviLauncher अपने-आप पूरा कर देगा।</string>
-    <string name="ms_device_code_label">Microsoft डिवाइस कोड</string>
-    <string name="ms_device_code_requesting">सुरक्षित कोड का अनुरोध किया जा रहा है…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">ब्राउज़र में आपके पूरा करने की प्रतीक्षा है…</string>
-    <string name="ms_device_code_checking">Microsoft साइन-इन परिणाम जाँचा जा रहा है…</string>
-    <string name="ms_device_code_reconnecting">कनेक्शन बदल गया। अपने-आप फिर प्रयास किया जा रहा है…</string>
-    <string name="ms_device_code_authorized">Microsoft ने साइन-इन स्वीकृत कर दिया। पूरा किया जा रहा है…</string>
-    <string name="ms_device_code_browser_opened">ब्राउज़र में नया Microsoft साइन-इन पूरा करें, फिर यहाँ वापस आएँ।</string>
-    <string name="ms_device_code_expires">कोड %1$d:%2$02d में समाप्त होगा</string>
-    <string name="ms_device_code_copy">कोड कॉपी करें</string>
-    <string name="ms_device_code_copied">कोड कॉपी किया गया</string>
-    <string name="ms_device_code_open_browser">Microsoft साइन-इन खोलें</string>
-    <string name="ms_device_code_step_title">अपने ब्राउज़र में साइन-इन पूरा करें</string>
-    <string name="ms_device_code_browser_note">LeviLauncher आपके डिफ़ॉल्ट ब्राउज़र को निजी सत्र में खोलता है, कोड अपने-आप भरता है और नया Microsoft साइन-इन अनुरोध करता है।</string>
-    <string name="ms_choose_other_method">अन्य तरीका</string>
-    <string name="ms_no_browser">इस डिवाइस पर कोई ब्राउज़र उपलब्ध नहीं है।</string>
-    <string name="ms_default_browser_no_private_mode">आपका डिफ़ॉल्ट ब्राउज़र निजी साइन-इन का समर्थन नहीं करता। इसे अपडेट करें या WebView लॉगिन का उपयोग करें।</string>
-    <string name="ms_login_ssl_failed">सुरक्षित Microsoft साइन-इन पेज सत्यापित नहीं किया जा सका।</string>
-    <string name="ms_login_state_failed">Microsoft साइन-इन प्रतिक्रिया सत्यापित नहीं की जा सकी। फिर से साइन-इन शुरू करें।</string>
-    <string name="ms_login_missing_code">Microsoft ने साइन-इन कोड नहीं दिया। फिर से साइन-इन शुरू करें या डिवाइस कोड लॉगिन का उपयोग करें।</string>
-    <string name="ms_feature_disabled_title">सुविधा अक्षम है</string>
-    <string name="ms_feature_disabled_desc">Microsoft खाते प्रबंधित करने के लिए सेटिंग्स में “LeviLauncher के साथ Minecraft में साइन इन करें” सक्षम करें।</string>
-    <string name="ms_activated">सक्रिय</string>
-    <string name="inbuilt_mod_gyro">जाइरोस्कोप</string>
-    <string name="inbuilt_mod_gyro_desc">कैमरा घुमाव नियंत्रित करने के लिए डिवाइस के जाइरोस्कोप का उपयोग करें</string>
-    <string name="inbuilt_mod_pojav_controls">Pojav नियंत्रण</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Minecraft टच नियंत्रणों को पूरी तरह अनुकूलन योग्य Pojav-शैली नियंत्रणों से बदलें</string>
-    <string name="inbuilt_mod_more_buttons">अधिक बटन</string>
-    <string name="inbuilt_mod_more_buttons_desc">एकल-कुंजी मैपिंग और SVG आइकन के साथ कस्टम ऑन-स्क्रीन बटन बनाएँ</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">हर जगह दिखाएँ</string>
-    <string name="mod_config_zoom_transition">ट्रांज़िशन अवधि (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">क्षैतिज संवेदनशीलता (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">ऊर्ध्वाधर संवेदनशीलता (%)</string>
-    <string name="mod_config_gyro_invert_x">क्षैतिज अक्ष उलटें</string>
-    <string name="mod_config_gyro_invert_y">ऊर्ध्वाधर अक्ष उलटें</string>
-    <string name="mod_config_gyro_deadzone">डेड ज़ोन</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">बंद करें</string>
     <string name="previous">पिछला</string>
     <string name="next">अगला</string>
@@ -924,6 +1022,8 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="custom_color_hint">#RRGGBB या R,G,B</string>
     <string name="screenshot_name_placeholder">स्क्रीनशॉट का नाम</string>
     <string name="screenshot_date_placeholder">दिनांक: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Minecraft-शैली के ऑन-स्क्रीन बटन बनाएँ, जिनमें प्रत्येक को ठीक एक कीबोर्ड कुंजी से मैप किया गया हो। बटन कभी भी मैक्रो, कुंजी अनुक्रम, स्वचालित रिपीट या ऑटोक्लिक नहीं चलाते।</string>
     <string name="more_buttons_add_button">बटन जोड़ें</string>
     <string name="more_buttons_limit_reached">अधिकतम %1$d कस्टम बटन की सीमा पूरी हो गई।</string>
@@ -981,99 +1081,17 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="more_buttons_no_svg_selected">कोई SVG चयनित नहीं</string>
     <string name="more_buttons_default_name">बटन</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">हॉटबार स्लॉट</string>
     <string name="inbuilt_mod_hotbar_slot_desc">हॉटबार स्लॉट चुनने के लिए अलग-अलग 1–9 बटन जोड़ता है</string>
     <string name="hotbar_slot_content_description">हॉटबार स्लॉट %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">होम स्क्रीन शॉर्टकट</string>
-    <string name="instance_shortcut_desc">नाम और आइकन में बदलाव अपने-आप सेव हो जाते हैं। होम स्क्रीन शॉर्टकट बनाने या अपडेट करने के लिए शॉर्टकट जोड़ें पर टैप करें।</string>
-    <string name="instance_shortcut_name">शॉर्टकट का नाम</string>
-    <string name="instance_shortcut_icon">शॉर्टकट आइकन</string>
-    <string name="instance_shortcut_choose_icon">आइकन चुनें</string>
-    <string name="instance_shortcut_default_icon">डिफ़ॉल्ट इस्तेमाल करें</string>
-    <string name="instance_shortcut_add_button">शॉर्टकट जोड़ें</string>
-    <string name="instance_settings_auto_save_failed">इस इंस्टेंस की सेटिंग सेव नहीं की जा सकी।</string>
-    <string name="instance_shortcut_not_supported">आपका होम स्क्रीन लॉन्चर पिन किए गए शॉर्टकट का समर्थन नहीं करता।</string>
-    <string name="instance_shortcut_missing">यह Minecraft इंस्टेंस अब उपलब्ध नहीं है।</string>
-    <string name="custom_flat_world_subtitle">अपने बायोम और ब्लॉक लेयर्स के साथ दुनिया बनाएँ</string>
-    <string name="world_settings">दुनिया की सेटिंग</string>
-    <string name="world_settings_hint">नई दुनिया के लिए मूल सेटिंग चुनें</string>
-    <string name="layers_title">लेयर्स</string>
-    <string name="add_layer_compact">लेयर जोड़ें</string>
-    <string name="no_layers_title">अभी कोई लेयर नहीं</string>
-    <string name="no_layers_hint">दुनिया बनाने के लिए कम से कम एक ब्लॉक लेयर जोड़ें</string>
-    <string name="reorder_layer">लेयर का क्रम बदलें</string>
-    <string name="delete_layer">लेयर हटाएँ</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">स्कैन करें</string>
-    <string name="scan_downloads_scanning">स्कैन हो रहा है…</string>
-    <string name="scan_downloads_none_found">Downloads में कोई .levipack या .so मॉड नहीं मिला</string>
-    <string name="scan_downloads_failed">Downloads को स्कैन नहीं किया जा सका</string>
-    <string name="scan_downloads_permission_denied">Downloads को स्कैन करने के लिए स्टोरेज एक्सेस चाहिए</string>
-    <string name="scan_downloads_results_title">Downloads में मॉड</string>
-    <string name="scan_downloads_results_subtitle">जोड़ने के लिए कोई मॉड चुनें। स्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है।</string>
-    <string name="scan_downloads_add">जोड़ें</string>
-    <string name="scan_downloads_adding">जोड़ा जा रहा है…</string>
-    <string name="scan_downloads_added">जोड़ दिया गया</string>
-    <string name="scan_downloads_added_message">%1$s जोड़ दिया गया</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">नेटिव लाइब्रेरी</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">बाहरी मॉड</string>
-    <string name="external_mods_subtitle">Minecraft %1$s के लिए कम्युनिटी मॉड</string>
-    <string name="external_mods_no_version">मॉड इंस्टॉल करने से पहले Minecraft का संस्करण चुनें</string>
-    <string name="external_mods_search_hint">मॉड, लेखक या संस्करण खोजें…</string>
-    <string name="external_mods_compatible_only">केवल संगत</string>
-    <string name="external_mods_all_versions">Minecraft के सभी संस्करण</string>
-    <string name="external_mods_sort_newest">सबसे नए</string>
-    <string name="external_mods_sort_name">नाम A–Z</string>
-    <string name="external_mods_empty">इन फ़िल्टर से कोई मॉड मेल नहीं खाता</string>
-    <string name="external_mods_load_failed">कैटलॉग रीफ़्रेश नहीं हो सका। सेव की गई कॉपी दिखाई जा रही है।</string>
-    <string name="external_mods_refresh">कैटलॉग रीफ़्रेश करें</string>
-    <string name="external_mods_refreshed">कैटलॉग रीफ़्रेश हो गया</string>
-    <string name="external_mods_join_discord">कम्युनिटी Discord से जुड़ें</string>
-    <string name="external_mods_discord_open_failed">कोई ऐप Discord आमंत्रण नहीं खोल सकता</string>
-    <string name="external_mods_download">%1$s डाउनलोड हो रहा है</string>
-    <string name="external_mods_importing">मॉड इम्पोर्ट हो रहा है…</string>
-    <string name="external_mods_installed">%1$s इंस्टॉल हो गया</string>
-    <string name="external_mods_install_failed">%1$s इंस्टॉल नहीं हो सका: %2$s</string>
-    <string name="external_mods_open_failed">कोई ब्राउज़र इस डाउनलोड को नहीं खोल सकता</string>
-    <string name="external_mods_direct_download">सीधा डाउनलोड</string>
-    <string name="external_mods_ad_download">विज्ञापन वाला डाउनलोड</string>
-    <string name="external_mods_external_link">बाहरी लिंक</string>
-    <string name="external_mods_open_link">लिंक खोलें</string>
-    <string name="external_mods_external_dialog_title">बाहरी डाउनलोड</string>
-    <string name="external_mods_ad_dialog_title">विज्ञापन-समर्थित डाउनलोड</string>
-    <string name="external_mods_external_dialog_message">%1$s LeviLauncher के बाहर की डाउनलोड वेबसाइट का उपयोग करता है।\n\n1. लिंक खोलें पर टैप करें और .levipack या .so फ़ाइल डाउनलोड करें।\n2. LeviLauncher पर वापस जाएँ और Mods खोलें।\n3. स्कैन करें पर टैप करें।\n4. जिस मॉड को इम्पोर्ट करना चाहते हैं, उसके पास जोड़ें पर टैप करें।\n\nस्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है। अगर ब्राउज़र ने फ़ाइल कहीं और सेव की है, तो उसे इस फ़ोल्डर में ले जाएँ।</string>
-    <string name="external_mods_ad_dialog_message">%1$s अपने डेवलपर द्वारा चुनी गई विज्ञापन-समर्थित डाउनलोड वेबसाइट का उपयोग करता है। LeviLauncher उस वेबसाइट या उसके विज्ञापनों को नियंत्रित नहीं करता।\n\n1. लिंक खोलें पर टैप करें और .levipack या .so फ़ाइल डाउनलोड करें।\n2. LeviLauncher पर वापस जाएँ और Mods खोलें।\n3. स्कैन करें पर टैप करें।\n4. जिस मॉड को इम्पोर्ट करना चाहते हैं, उसके पास जोड़ें पर टैप करें।\n\nस्कैन केवल मुख्य Downloads फ़ोल्डर की जाँच करता है। केवल मॉड फ़ाइल डाउनलोड करें; असंबंधित ऐप इंस्टॉल न करें और नोटिफिकेशन की अनुमति न दें।</string>
-    <string name="external_mods_by_author">%1$s द्वारा</string>
-    <string name="external_mods_version">मॉड %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">अपडेट करें</string>
-    <string name="external_mods_installed_button">इंस्टॉल किया गया</string>
-    <string name="external_mods_incompatible">असंगत</string>
-    <string name="foreground_service">फ़ोरग्राउंड सेवा</string>
-    <string name="foreground_service_desc">ऐप बदलते समय Bedrock को सक्रिय सेशन सस्पेंड करने से रोककर और प्रोसेस, CPU तथा Wi-Fi को सक्रिय रखकर Minecraft को चलता रहने देता है।</string>
-    <string name="foreground_service_warning">नोट: इससे फ़ोन जल्दी गर्म हो सकता है और बैटरी की खपत बढ़ सकती है।</string>
-    <string name="foreground_service_channel">Minecraft बैकग्राउंड सुरक्षा</string>
-    <string name="foreground_service_notification_title">Minecraft को सक्रिय रखा जा रहा है</string>
-    <string name="foreground_service_notification_text">Minecraft का बैकग्राउंड मोड सक्रिय है। मौजूदा सेशन के लिए CPU और नेटवर्क एक्सेस उपलब्ध रखे जा रहे हैं।</string>
-    <string name="mod_menu_compact">कॉम्पैक्ट मॉड मेनू</string>
-    <string name="mod_menu_compact_desc">घनी मॉड्यूल सूची और कॉम्पैक्ट फ़िल्टर वाला छोटा मेनू इस्तेमाल करें</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">संवेदनशीलता गुणक (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">क्षैतिज गति (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">ऊर्ध्वाधर गति (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">छोटी गति फ़िल्टर (0 = बंद)</string>
-    <string name="hud_editor_drag_hint">पैनल को ले जाने के लिए खींचें</string>
-    <string name="hud_editor_drag_description">HUD एडिटर। पैनल को ले जाने के लिए इस क्षेत्र को खींचें।</string>
     <string name="mod_config_hotbar_item_icons">हॉटबार के आइटम आइकन इस्तेमाल करें</string>
     <string name="mod_config_hotbar_item_counts">आइटम की संख्या दिखाएँ</string>
     <string name="mod_config_hotbar_slot_enabled">हॉटबार स्लॉट %1$d दिखाएँ</string>
     <string name="mod_config_hotbar_slot_size">हॉटबार स्लॉट %1$d का आकार (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">हॉटबार स्लॉट %1$d की अपारदर्शिता</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">नया क्या है</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">जारी रखें</string>
@@ -1096,6 +1114,7 @@ LeviLauncher जारी रखने से पहले माइग्रे
     <string name="mod_config_category_button">बटन</string>
     <string name="mod_config_visible_slots">दिखने वाले स्लॉट</string>
     <string name="mod_config_hotbar_slot_section">हॉटबार स्लॉट %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">चुनें</string>
     <string name="select_all">सभी चुनें</string>
     <string name="selected">चुना गया</string>

--- a/app/src/main/res/values-idn/strings.xml
+++ b/app/src/main/res/values-idn/strings.xml
@@ -1,3 +1,11 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -5,6 +13,9 @@
     <string name="launch">Luncurkan</string>
     <string name="beta_badge">Beta</string>
     <string name="debug_badge">Debug</string>
+    <string name="cursor">Kursor</string>
+    <string name="bedrock_edition">Edisi Bedrock</string>
+    <string name="current_instance">Instans Saat Ini</string>
 
     <!-- Mods -->
     <string name="mods_title">Mods (%d)</string>
@@ -23,6 +34,9 @@
     <string name="font_license">Aplikasi ini menggunakan font Misans..</string>
     <string name="about_footer_github">GitHub: https://github.com/LiteLDev/LeviLaunchroid</string>
     <string name="quick_actions_title">Tindakan Cepat</string>
+    <string name="content_mgmt_section_title">Manajemen Konten</string>
+    <string name="misc_section_title">Lain-lain</string>
+    <string name="view_all">Lihat Semua →</string>
     <string name="content_management_subtitle">Kelola Dunia, Paket Sumber Daya and Paket Perilaku</string>
     <string name="import_apk_subtitle">Install Minecraft Dari APK Atau APKS file</string>
     <string name="ms_add_account">Tambahkan Akun</string>
@@ -37,6 +51,11 @@
 
     <string name="import_confirmation_title">Impor Mod</string>
     <string name="import_confirmation_message">Apakah Anda yakin ingin mengimpor %d file mod yang dipilih?</string>
+    <string name="import_so_plugin_title">Impor Plugin SO</string>
+    <string name="plugin_name_label">Nama Plugin</string>
+    <string name="plugin_type_label">Jenis</string>
+    <string name="plugin_version_label">Versi</string>
+    <string name="import_button">Impor</string>
     <string name="overwrite_file_title">File Sudah Ada</string>
     <string name="overwrite_file_message">File %s sudah ada. Apakah Anda ingin menimpanya?</string>
     <string name="overwrite">Timpa</string>
@@ -84,12 +103,20 @@
 
     <string name="settings_title">Pengaturan</string>
     <string name="settings_desc">Pengaturan peluncur Anda</string>
+    <string name="settings_subtitle">Konfigurasikan opsi launcher umum</string>
+    <string name="settings_tab_basic">Pengaturan Dasar</string>
+    <string name="settings_tab_personalize">Personalisasi</string>
+    <string name="settings_tab_updates">Pembaruan</string>
+    <string name="settings_tab_about">Tentang</string>
+    <string name="settings_tab_migration">Migrasi</string>
+    <string name="settings_theme_desc">Pilih tema aplikasi</string>
+
 
     <string name="unknown_sources_permission_title">Izin Instalasi</string>
     <string name="unknown_sources_permission_message">Untuk menginstal atau memperbarui aplikasi ini, mohon berikan izin untuk menginstal aplikasi yang tidak dikenal. Klik "Izinkan" untuk membuka pengaturan sistem, aktifkan izin untuk aplikasi ini, dan kembali untuk melanjutkan.</string>
 
     <string name="check_update">Periksa pembaruan</string>
-    <string name="version_prefix">Versi: </string>
+    <string name="version_prefix">Versi:</string>
     <string name="unknown_error">Kesalahan tidak diketahui</string>
     <string name="preloader_sigs_title">Data runtime</string>
     <string name="preloader_sigs_last_update">Pembaruan terakhir: %1$s</string>
@@ -113,6 +140,8 @@
     <string name="dialog_message_disable_version_isolation">Anda mencoba menjalankan versi yang sudah terpasang dengan isolasi versi diaktifkan. Harap nonaktifkan isolasi versi untuk melanjutkan..</string>
     <string name="dialog_positive_disable">Matikan</string>
     <string name="dialog_positive_ok">OK</string>
+    <string name="delete_account_title">Hapus Akun</string>
+    <string name="delete_account_confirm">Yakin ingin menghapus akun ini?</string>
 
 
     <string name="new_version_found">Versi baru ditemukan: %1$s</string>
@@ -141,6 +170,7 @@
     <string name="repair_preparing">Persiapan…</string>
     <string name="repair_processing">Mengekstrak pustaka…</string>
     <string name="repair_finalizing">Menyelesaikan perbaikan…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Migrasi Penyimpanan Diperlukan</string>
     <string name="storage_migration_message">LeviLauncher harus memigrasikan data dari games/org.levimc ke %1$s sebelum melanjutkan.
 
@@ -185,21 +215,21 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="shared_storage_layout_mode_legacy">Direktori internal/eksternal asli</string>
     <string name="shared_storage_layout_status">Mode saat ini: %1$s\nInternal: %2$s\nExternal: %3$s</string>
     <string name="shared_storage_layout_changed">Pilihan direktori penyimpanan diperbarui. Mulai ulang Minecraft dan buka kembali manajemen konten agar perubahan diterapkan sepenuhnya.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Mode Tema</string>
     <string name="theme_follow_system">Ikuti Sistem</string>
     <string name="theme_light">Mode Siang</string>
     <string name="theme_dark">Mode Malam</string>
 
     <string name="error_no_browser">Tidak ada peramban yang tersedia.</string>
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher License Agreement</string>
     <string name="eula_message"><b>Selamat datang di LeviLauncher</b>\n\nBy using this software you agree to:\n\n• This is an <b>unofficial</b> Minecraft launcher\n• You must own a <b>licensed</b> copy of Minecraft\n• Any form of piracy or cheating is prohibited\n• Mods/resource packs are used at your own risk\n• Not affiliated with Mojang/Microsoft\n\nContinued use constitutes agreement</string>
     <string name="eula_agree">Terima</string>
     <string name="eula_exit">Tolak</string>
 
     <string name="allow_unknown_sources">Harap izinkan instalasi dari sumber yang tidak dikenal sebelum melanjutkan.</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Hapus Versi</string>
     <string name="dialog_message_delete_version">Apakah Anda yakin ingin menghapus versi kustom ini? Tindakan ini tidak dapat dibatalkan.</string>
     <string name="dialog_positive_delete">Menghapus</string>
@@ -217,8 +247,68 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="dialog_message_delete_mod">Apakah Anda yakin ingin menghapus mod ini?</string>
 
     <string name="version_isolation">Isolasi Versi</string>
+    <string name="launch_vertically">Luncurkan Vertikal</string>
+    <string name="launch_vertically_desc">Paksa game diluncurkan dalam mode potret</string>
+    <!-- Instance Management -->
+    <string name="instance_settings_title">Pengaturan Instans</string>
+    <string name="instance_tab_general">Umum</string>
+    <string name="instance_tab_launch_options">Opsi Peluncuran</string>
+    <string name="instance_tab_management">Manajemen</string>
+    <string name="instance_new_name">Nama Baru</string>
+    <string name="instance_rename_hint">Hanya mengganti nama folder. Versi dan jenis game tidak terpengaruh.</string>
+    <string name="instance_custom_icon">Ikon Kustom (harus persegi)</string>
+    <string name="instance_clear_icon">Bersihkan</string>
+    <string name="instance_icon_hint">Akan disimpan sebagai LargeLogo.png di folder versi. Ketuk ikon untuk mengubah.</string>
+    <string name="instance_isolation_desc">Pisahkan data game untuk instans ini. Instans lain tidak akan terpengaruh.</string>
+    <string name="instance_shortcut_title">Pintasan Layar Utama</string>
+    <string name="instance_shortcut_desc">Perubahan nama dan ikon disimpan otomatis. Ketuk Tambah Pintasan untuk membuat atau memperbarui pintasan layar utama.</string>
+    <string name="instance_shortcut_name">Nama Pintasan</string>
+    <string name="instance_shortcut_icon">Ikon Pintasan</string>
+    <string name="instance_shortcut_choose_icon">Pilih Ikon</string>
+    <string name="instance_shortcut_default_icon">Gunakan Bawaan</string>
+    <string name="instance_shortcut_add_button">Tambah Pintasan</string>
+    <string name="instance_settings_auto_save_failed">Tidak dapat menyimpan pengaturan instans ini.</string>
+    <string name="instance_shortcut_not_supported">Peluncur layar utama Anda tidak mendukung pintasan yang disematkan.</string>
+    <string name="instance_shortcut_missing">Instans Minecraft ini sudah tidak tersedia.</string>
+    <string name="instance_danger_zone">Zona Berbahaya</string>
+    <string name="instance_danger_zone_desc">Tindakan ini memengaruhi pendaftaran instans atau file lokal. Periksa kembali sebelum melanjutkan.</string>
+    <string name="instance_delete_desc">Menghapus instans ini secara permanen dari perangkat, termasuk dunia, konfigurasi, dan konten terpasang.</string>
+    <string name="instance_delete_warning">Tindakan ini tidak dapat dibatalkan.</string>
+    <string name="instance_delete_confirm_title">Hapus Instans</string>
+    <string name="instance_delete_confirm_msg">Apakah Anda yakin ingin menghapus instans ini? Semua data, termasuk dunia, akan dihapus permanen.</string>
+    <string name="instance_backup_title">Cadangkan Instans</string>
+    <string name="instance_backup_desc">Buat cadangan lengkap instans ini di Download/LeviLauncher/Backups.</string>
+    <string name="instance_backup_button">Cadangkan Instans</string>
+    <string name="instance_backup_confirm_message">Buat cadangan lengkap instans ini sekarang? Tutup Minecraft terlebih dahulu jika sedang berjalan agar file tidak berubah selama pencadangan.</string>
+    <string name="instance_backup_in_progress">Mencadangkan instans…</string>
+    <string name="instance_backup_success_title">Cadangan Dibuat</string>
+    <string name="instance_backup_success_message">Cadangan disimpan ke:\n%1$s</string>
+    <string name="instance_backup_failed_title">Pencadangan Gagal</string>
+    <string name="instance_backup_failed_message">Tidak dapat membuat cadangan:\n%1$s</string>
+    <string name="instance_import_backup_button">Impor Cadangan</string>
+    <string name="instance_batch_backup_button">Cadangkan Massal</string>
+    <string name="instance_batch_backup_title">Cadangkan Instans Massal</string>
+    <string name="instance_batch_backup_select_message">Pilih instans yang ingin dicadangkan. Jika Minecraft sedang berjalan, keluar terlebih dahulu agar data tidak berubah saat pencadangan.</string>
+    <string name="instance_batch_backup_select_all">Pilih semua instans</string>
+    <string name="instance_batch_backup_no_instances">Tidak ada instans yang tersedia untuk dicadangkan.</string>
+    <string name="instance_batch_backup_no_selection">Pilih setidaknya satu instans.</string>
+    <string name="instance_batch_backup_in_progress">Mencadangkan %1$s (%2$d/%3$d)…</string>
+    <string name="instance_batch_backup_success_title">Cadangan Dibuat</string>
+    <string name="instance_batch_backup_success_message">Membuat %1$d cadangan:\n%2$s</string>
+    <string name="instance_batch_backup_partial_title">Pencadangan Selesai Sebagian</string>
+    <string name="instance_batch_backup_partial_message">Membuat %1$d cadangan, %2$d gagal.\n\nTersimpan:\n%3$s\n\nGagal:\n%4$s</string>
+    <string name="instance_batch_backup_failed_title">Pencadangan Massal Gagal</string>
+    <string name="instance_batch_backup_failed_message">Tidak dapat membuat cadangan apa pun:\n%1$s</string>
+    <string name="instance_restore_title">Pulihkan Cadangan</string>
+    <string name="instance_restore_in_progress">Memulihkan cadangan instans…</string>
+    <string name="instance_restore_success_title">Pemulihan Selesai</string>
+    <string name="instance_restore_success_message">Dipulihkan: %1$s</string>
+    <string name="instance_restore_failed_title">Pemulihan Gagal</string>
+    <string name="instance_restore_failed_message">Tidak dapat memulihkan cadangan:\n%1$s</string>
 
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Bahasa (Language)</string>
     <string name="english">Inggris (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -251,6 +341,8 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="resource_packs_category">Paket Sumber Daya</string>
     <string name="behavior_packs_category">Paket Perilaku</string>
     <string name="skin_packs_category">Paket Kulit(skin)</string>
+    <string name="screenshots_category">Tangkapan Layar</string>
+    <string name="servers_category">Server</string>
     <string name="storage_internal">Internal</string>
     <string name="storage_external">External</string>
     <string name="storage_version_isolation">Isolasi Versi</string>
@@ -310,6 +402,8 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="edit_world">Edit Dunia</string>
     <string name="edit">Edit</string>
     <string name="save">Simpan</string>
+    <string name="reset">Reset</string>
+    <string name="saved_to_gallery">Disimpan ke galeri</string>
     <string name="level_dat_not_found">level.dat tidak ditemukan</string>
     <string name="no_editable_properties">Tidak ditemukan properti yang dapat diedit.</string>
     <string name="no_data">Tidak ada data</string>
@@ -333,6 +427,20 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="add_at_least_one_layer">Tambahkan satu lapisan</string>
     <string name="world_created_successfully">Dunia tercipta dengan sukses.</string>
     <string name="failed_to_create_world">Gagal menciptakan dunia</string>
+    <string name="custom_flat_world_subtitle">Buat dunia dengan bioma dan lapisan blok pilihan Anda sendiri</string>
+    <string name="world_settings">Pengaturan Dunia</string>
+    <string name="world_settings_hint">Pilih pengaturan dasar untuk dunia baru</string>
+    <string name="layers_title">Lapisan</string>
+    <string name="add_layer_compact">Tambah Lapisan</string>
+    <string name="no_layers_title">Belum ada lapisan</string>
+    <string name="no_layers_hint">Tambahkan setidaknya satu lapisan blok untuk membuat dunia</string>
+    <string name="reorder_layer">Susun ulang lapisan</string>
+    <string name="delete_layer">Hapus lapisan</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d lapisan • bawah → atas</item>
+        <item quantity="other">%1$d lapisan • bawah → atas</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Versi Play Store Diperlukan</string>
@@ -344,10 +452,57 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="genuine_badge_label">Lisensi tidak ter-verifikasi</string>
     <string name="invalid_license_detected_toast">Minecraft palsu terdeteksi. Pastikan Minecraft Anda berasal dari Google Play Store.</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Total Mods:</string>
     <string name="enabled_mods">Aktif:</string>
     <string name="add_mod">Tambahkan Mod</string>
+    <string name="scan_downloads">Pindai</string>
+    <string name="scan_downloads_scanning">Memindai…</string>
+    <string name="scan_downloads_none_found">Tidak ada mod .levipack atau .so yang ditemukan di Unduhan</string>
+    <string name="scan_downloads_failed">Tidak dapat memindai Unduhan</string>
+    <string name="scan_downloads_permission_denied">Akses penyimpanan diperlukan untuk memindai Unduhan</string>
+    <string name="scan_downloads_results_title">Mod di Unduhan</string>
+    <string name="scan_downloads_results_subtitle">Pilih mod untuk ditambahkan. Pemindaian hanya memeriksa folder utama Unduhan.</string>
+    <string name="scan_downloads_add">Tambah</string>
+    <string name="scan_downloads_adding">Menambahkan…</string>
+    <string name="scan_downloads_added">Ditambahkan</string>
+    <string name="scan_downloads_added_message">%1$s ditambahkan</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Pustaka native</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Mod Eksternal</string>
+    <string name="external_mods_subtitle">Mod komunitas untuk Minecraft %1$s</string>
+    <string name="external_mods_no_version">Pilih versi Minecraft sebelum memasang mod</string>
+    <string name="external_mods_search_hint">Cari mod, pembuat, atau versi…</string>
+    <string name="external_mods_compatible_only">Hanya yang kompatibel</string>
+    <string name="external_mods_all_versions">Semua versi Minecraft</string>
+    <string name="external_mods_sort_newest">Terbaru</string>
+    <string name="external_mods_sort_name">Nama A–Z</string>
+    <string name="external_mods_empty">Tidak ada mod yang cocok dengan filter ini</string>
+    <string name="external_mods_load_failed">Tidak dapat menyegarkan katalog. Menampilkan salinan yang tersimpan.</string>
+    <string name="external_mods_refresh">Segarkan katalog</string>
+    <string name="external_mods_refreshed">Katalog disegarkan</string>
+    <string name="external_mods_join_discord">Gabung Discord Komunitas</string>
+    <string name="external_mods_discord_open_failed">Tidak ada aplikasi yang dapat membuka undangan Discord</string>
+    <string name="external_mods_download">Mengunduh %1$s</string>
+    <string name="external_mods_importing">Mengimpor mod…</string>
+    <string name="external_mods_installed">%1$s terpasang</string>
+    <string name="external_mods_install_failed">Tidak dapat memasang %1$s: %2$s</string>
+    <string name="external_mods_open_failed">Tidak ada browser yang dapat membuka unduhan ini</string>
+    <string name="external_mods_direct_download">Unduhan langsung</string>
+    <string name="external_mods_ad_download">Unduhan dengan iklan</string>
+    <string name="external_mods_external_link">Tautan eksternal</string>
+    <string name="external_mods_open_link">Buka Tautan</string>
+    <string name="external_mods_external_dialog_title">Unduhan Eksternal</string>
+    <string name="external_mods_ad_dialog_title">Unduhan dengan Iklan</string>
+    <string name="external_mods_external_dialog_message">%1$s menggunakan halaman unduhan di luar LeviLauncher.\n\n1. Ketuk Buka Tautan dan unduh file .levipack atau .so.\n2. Kembali ke LeviLauncher dan buka Mod.\n3. Ketuk Pindai.\n4. Ketuk Tambah di sebelah mod yang ingin Anda impor.\n\nPemindaian hanya memeriksa folder utama Unduhan. Pindahkan file ke sana jika browser menyimpannya di tempat lain.</string>
+    <string name="external_mods_ad_dialog_message">%1$s menggunakan halaman unduhan dengan iklan yang dipilih oleh pengembangnya. LeviLauncher tidak mengontrol halaman tersebut atau iklannya.\n\n1. Ketuk Buka Tautan dan unduh file .levipack atau .so.\n2. Kembali ke LeviLauncher dan buka Mod.\n3. Ketuk Pindai.\n4. Ketuk Tambah di sebelah mod yang ingin Anda impor.\n\nPemindaian hanya memeriksa folder utama Unduhan. Unduh hanya file mod; jangan memasang aplikasi yang tidak terkait atau mengizinkan notifikasi.</string>
+    <string name="external_mods_by_author">oleh %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Perbarui</string>
+    <string name="external_mods_installed_button">Terpasang</string>
+    <string name="external_mods_incompatible">Tidak kompatibel</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">Detail Mod</string>
@@ -357,6 +512,57 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="mod_disabled">Mod dinonaktifkan</string>
     <string name="mod_filename_format">File: %s</string>
     <string name="mod_enable_status">Status</string>
+    <string name="mod_icon_content_description">Ikon mod</string>
+    <string name="mod_author_byline">oleh %s</string>
+    <string name="mod_version_chip">Versi %s</string>
+    <string name="mod_metadata_title">Informasi</string>
+    <string name="mod_actions_title">Tindakan</string>
+    <string name="mod_author_label">Pembuat</string>
+    <string name="mod_version_label">Versi</string>
+    <string name="mod_minecraft_versions_label">Versi Minecraft</string>
+    <string name="mod_entry_label">File Entri</string>
+    <string name="mod_id_label">ID Mod</string>
+    <string name="mod_config_files_label">File Konfigurasi</string>
+    <string name="mod_unknown_author">Pembuat tidak diketahui</string>
+    <string name="mod_unknown_version">Versi tidak diketahui</string>
+    <string name="mod_all_versions">Semua versi yang didukung</string>
+    <string name="mod_no_config_files">Tidak ada konfigurasi yang dapat diedit</string>
+    <string name="mod_config_badge">KONFIG</string>
+    <string name="mod_config_badge_with_count">KONFIG · %d</string>
+    <string name="mod_config_title_format">Konfigurasi %s</string>
+    <string name="mod_config_not_found">Tidak ada konfigurasi yang dapat diedit</string>
+    <string name="mod_config_load_failed">Gagal memuat konfigurasi: %s</string>
+    <string name="mod_config_save_failed">Gagal menyimpan konfigurasi</string>
+    <string name="mod_config_saved">Konfigurasi disimpan</string>
+    <string name="mod_config_restart_hint">File konfigurasi disimpan dan file .backup dipertahankan.</string>
+    <string name="mod_config_validation_failed">Validasi konfigurasi gagal</string>
+    <string name="mod_config_invalid_json">JSON tidak valid</string>
+    <string name="mod_config_expand">Buka</string>
+    <string name="mod_config_collapse">Tutup</string>
+    <string name="mod_config_raw_json">Edit JSON asli</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">Item %1$s</string>
+    <string name="mod_config_object_desc">Grup pengaturan terkait</string>
+    <string name="mod_config_array_desc">Daftar nilai</string>
+    <string name="mod_config_range_prefix">Rentang</string>
+    <string name="mod_config_error_number">%1$s harus berupa angka</string>
+    <string name="mod_config_error_minimum">%1$s minimal harus %2$s</string>
+    <string name="mod_config_error_maximum">%1$s maksimal harus %2$s</string>
+    <string name="mod_config_error_boolean">%1$s harus aktif atau nonaktif</string>
+    <string name="mod_config_error_string">%1$s harus berupa teks</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d konfigurasi dapat diedit</item>
+        <item quantity="other">%d konfigurasi dapat diedit</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d pilihan</item>
+        <item quantity="other">%d pilihan</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d item</item>
+        <item quantity="other">%d item</item>
+    </plurals>
 
     <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">Pilih Versi Game</string>
@@ -387,13 +593,45 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="accounts_active_privilege">Sudah masuk</string>
 
     <string name="ms_login_title">Login Microsoft</string>
+    <string name="ms_login_header_subtitle">Masuk ke Minecraft dengan aman</string>
     <string name="ms_login_starting">Memulai proses login Microsoft…</string>
     <string name="ms_login_exchanging">Menukarkan token…</string>
     <string name="ms_login_auth_xbox_device">Memverifikasi perangkat Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Mengambil identitas akun Minecraft…</string>
+    <string name="ms_login_retrying">Koneksi terputus. Mencoba ulang dengan aman…</string>
     <string name="ms_login_success">Masuk sebagai %1$s</string>
     <string name="ms_login_failed">Login Microsoft gagal</string>
     <string name="ms_login_failed_detail">Login gagal: %1$s</string>
+    <string name="ms_choose_login_method">Masuk ke Minecraft</string>
+    <string name="ms_choose_login_method_desc">Pilih alur kode perangkat berbasis browser atau lanjutkan dengan halaman Microsoft tertanam.</string>
+    <string name="ms_device_code_login">Lanjutkan dengan browser</string>
+    <string name="ms_device_code_option_title">Kode Perangkat (Disarankan)</string>
+    <string name="ms_device_code_login_desc">Buka sesi browser privat dengan kode perangkat yang sudah terisi.</string>
+    <string name="ms_webview_login">Buka masuk tertanam</string>
+    <string name="ms_webview_option_title">WebView Tertanam</string>
+    <string name="ms_webview_login_desc">Masuk tanpa meninggalkan LeviLauncher. Gunakan saat alur browser tidak tersedia.</string>
+    <string name="ms_device_code_title">Masuk dengan Kode Perangkat</string>
+    <string name="ms_device_code_instructions">Buka halaman masuk perangkat Microsoft, masukkan kode ini, lalu setujui akses. LeviLauncher akan menyelesaikannya secara otomatis.</string>
+    <string name="ms_device_code_label">Kode perangkat Microsoft</string>
+    <string name="ms_device_code_requesting">Meminta kode aman…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Menunggu Anda menyelesaikannya di browser…</string>
+    <string name="ms_device_code_checking">Memeriksa hasil masuk Microsoft…</string>
+    <string name="ms_device_code_reconnecting">Koneksi berubah. Mencoba ulang secara otomatis…</string>
+    <string name="ms_device_code_authorized">Microsoft menyetujui proses masuk. Menyelesaikan…</string>
+    <string name="ms_device_code_browser_opened">Selesaikan proses masuk Microsoft yang baru di browser, lalu kembali ke sini.</string>
+    <string name="ms_device_code_expires">Kode kedaluwarsa dalam %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Salin Kode</string>
+    <string name="ms_device_code_copied">Kode disalin</string>
+    <string name="ms_device_code_open_browser">Buka masuk Microsoft</string>
+    <string name="ms_device_code_step_title">Selesaikan proses masuk di browser Anda</string>
+    <string name="ms_device_code_browser_note">LeviLauncher membuka browser default Anda dalam sesi privat, mengisi kode secara otomatis, dan meminta proses masuk Microsoft yang baru.</string>
+    <string name="ms_choose_other_method">Metode lain</string>
+    <string name="ms_no_browser">Tidak ada browser yang tersedia di perangkat ini.</string>
+    <string name="ms_default_browser_no_private_mode">Browser default Anda tidak mendukung masuk secara privat. Perbarui browser atau gunakan login WebView.</string>
+    <string name="ms_login_ssl_failed">Halaman masuk Microsoft yang aman tidak dapat diverifikasi.</string>
+    <string name="ms_login_state_failed">Respons masuk Microsoft tidak dapat diverifikasi. Mulai proses masuk lagi.</string>
+    <string name="ms_login_missing_code">Microsoft tidak mengembalikan kode masuk. Mulai proses masuk lagi atau gunakan login Kode Perangkat.</string>
 
     <string name="ms_set_active">Aktifkan</string>
     <string name="ms_delete">Hapus</string>
@@ -406,10 +644,14 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="go_to_accounts">Akun</string>
     <string name="disable_launcher_login_and_continue">Tutup</string>
 
+    <string name="ms_feature_disabled_title">Fitur Dinonaktifkan</string>
+    <string name="ms_feature_disabled_desc">Aktifkan “Masuk ke Minecraft dengan LeviLauncher” di Pengaturan untuk mengelola akun Microsoft.</string>
+    <string name="ms_activated">Diaktifkan</string>
+
     <!-- Popup labels -->
     <string name="label_current_account">Akun Sekarang</string>
     <string name="label_other_accounts">Akun Lain</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">Aplikasi mengalami kerusakan.</string>
     <string name="crash_upload">Unggah laporan kerusakan</string>
     <string name="crash_details_title">Detail kerusakan</string>
@@ -428,6 +670,12 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="dialog_message_exit_app">Apakah Anda yakin ingin keluar?</string>
     <string name="dialog_positive_exit">Keluar</string>
     <string name="show_logcat_overlay">Logcat overlay</string>
+    <string name="foreground_service">Layanan latar depan</string>
+    <string name="foreground_service_desc">Biarkan Minecraft tetap berjalan saat Anda berpindah aplikasi dengan mencegah Bedrock menangguhkan sesi aktif serta menjaga proses, CPU, dan Wi-Fi tetap aktif.</string>
+    <string name="foreground_service_warning">Catatan: Dapat membuat ponsel lebih cepat panas dan meningkatkan penggunaan baterai.</string>
+    <string name="foreground_service_channel">Perlindungan Minecraft di latar belakang</string>
+    <string name="foreground_service_notification_title">Minecraft tetap dijaga aktif</string>
+    <string name="foreground_service_notification_text">Mode latar belakang Minecraft aktif. CPU dan akses jaringan tetap tersedia untuk sesi saat ini.</string>
     <string name="logcat_live">Logcat: <b>hidup(live)</b></string>
     <string name="logcat_paused">Logcat: terhenti</string>
     <!-- Logcat Overlay i18n -->
@@ -475,12 +723,25 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="inbuilt_mod_cps_display_desc">Menampilkan jumlah klik per detik</string>
     <string name="inbuilt_mod_snaplook">Snaplook</string>
     <string name="inbuilt_mod_snaplook_desc">Tahan untuk melihat ke belakang dengan cepat (orang ketiga depan)</string>
+    <string name="inbuilt_mod_virtual_cursor">Kursor Virtual</string>
+    <string name="inbuilt_mod_virtual_cursor_desc">Gunakan trackpad virtual untuk mengontrol mouse</string>
+    <string name="virtual_cursor_enabled">Kursor diaktifkan</string>
+    <string name="virtual_cursor_disabled">Kursor dinonaktifkan</string>
+    <string name="cursor_sensitivity_label">Sensitivitas Kursor:</string>
+    <string name="inbuilt_mod_gyro">Giroskop</string>
+    <string name="inbuilt_mod_gyro_desc">Gunakan giroskop perangkat untuk mengontrol rotasi kamera</string>
+    <string name="inbuilt_mod_pojav_controls">Kontrol Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Ganti kontrol sentuh Minecraft dengan kontrol gaya Pojav yang sepenuhnya dapat disesuaikan</string>
+    <string name="inbuilt_mod_more_buttons">Lebih Banyak Tombol</string>
+    <string name="inbuilt_mod_more_buttons_desc">Buat tombol layar kustom dengan pemetaan satu tombol keyboard dan ikon SVG</string>
     <string name="inbuilt_badge">BAWAAN</string>
     <string name="autosprint_keybind_label">Tombol Auto Sprint:</string>
     <string name="autosprint_keybind_press">Tekan tombol apa saja…</string>
     <string name="configure">Konfigurasi</string>
     <string name="overlay_button_size">Ukuran Tombol Overlay</string>
     <string name="overlay_button_opacity">Opasitas Tombol Overlay</string>
+    <string name="overlay_button_size_value">Ukuran: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Opasitas: %1$d%%</string>
     <string name="overlay_button_lock">Kunci Posisi</string>
     <string name="overlay_button_lock_desc">Mencegah penyeretan dan aktivasi tidak sengaja</string>
     <string name="settings">Pengaturan</string>
@@ -502,13 +763,33 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <!-- Mod Menu -->
     <string name="mod_menu">Menu Mod</string>
     <string name="mod_menu_modules">Modul</string>
+    <string name="mod_menu_favorites">Favorit</string>
+    <string name="mod_menu_favorite">Tambahkan ke favorit</string>
+    <string name="mod_menu_unfavorite">Hapus dari favorit</string>
+    <string name="mod_menu_hud_editor">Editor HUD</string>
+    <string name="mod_menu_filter_enabled">Aktif</string>
+    <string name="mod_menu_filter_inbuilt">Bawaan</string>
+    <string name="mod_menu_filter_external">Eksternal</string>
     <string name="mod_menu_search_hint">Cari mod…</string>
     <string name="mod_menu_no_mods">Tidak ada mod yang ditambahkan</string>
+    <string name="mod_menu_no_favorites">Belum ada mod favorit</string>
+    <string name="mod_menu_no_matches">Tidak ada mod yang cocok</string>
+    <string name="mod_menu_group_inbuilt">Fitur Bawaan</string>
+    <string name="mod_menu_group_external_ungrouped">Mod Eksternal Tidak Dikelompokkan</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Pengaturan Umum</string>
+    <string name="mod_menu_appearance">Tampilan</string>
+    <string name="mod_menu_pause_menu_only">Hanya Menu Jeda</string>
+    <string name="mod_menu_pause_menu_only_desc">Tampilkan menu mod hanya di layar jeda</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Pengaturan segera hadir</string>
     <string name="mod_menu_notifications">Notifikasi</string>
     <string name="mod_menu_notifications_desc">Tampilkan notifikasi saat mengaktifkan mod</string>
     <string name="mod_menu_opacity">Opasitas Menu Mod</string>
     <string name="mod_menu_button_opacity">Opasitas Tombol Menu Mod</string>
+    <string name="mod_menu_compact">Menu Mod Ringkas</string>
+    <string name="mod_menu_compact_desc">Gunakan menu yang lebih kecil dengan daftar modul yang padat dan filter ringkas</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Menu Mod diaktifkan</string>
     <string name="mod_menu_disabled">Menu Mod dinonaktifkan</string>
@@ -517,6 +798,35 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="mod_status_enabled">Diaktifkan</string>
     <string name="mod_status_disabled">Dinonaktifkan</string>
     <string name="mod_notification_enabled">%s diaktifkan</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Ukuran Tombol Overlay (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Opasitas Overlay (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Tampilkan di Mana Saja</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensitivitas Kursor (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Level Zoom (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Keybind Sprint Otomatis</string>
+    <string name="mod_config_zoom_keybind">Keybind Zoom</string>
+    <string name="mod_config_zoom_transition">Durasi Transisi (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Pengali Sensitivitas (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Kecepatan Horizontal (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Kecepatan Vertikal (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Filter Gerakan Kecil (0 = Nonaktif)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensitivitas Horizontal (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensitivitas Vertikal (%)</string>
+    <string name="mod_config_gyro_invert_x">Balik Sumbu Horizontal</string>
+    <string name="mod_config_gyro_invert_y">Balik Sumbu Vertikal</string>
+    <string name="mod_config_gyro_deadzone">Zona Mati</string>
+    <string name="mod_config_press_any_key">Tekan tombol apa saja untuk mengikat...</string>
+    <string name="mod_config_key_unknown">TIDAK DIKETAHUI</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Seret untuk memindahkan panel</string>
+    <string name="hud_editor_drag_description">Editor HUD. Seret area ini untuk memindahkan panel.</string>
 
     <!-- Options Editor -->
     <string name="edit_options">Edit Opsi</string>
@@ -596,69 +906,13 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="curseforge_download_failed">Gagal mengunduh</string>
     <string name="curseforge_available_files">File yang Tersedia</string>
 
-    <!-- Missing translations -->
-    <string name="cursor">Kursor</string>
-    <string name="bedrock_edition">Edisi Bedrock</string>
-    <string name="current_instance">Instans Saat Ini</string>
-    <string name="content_mgmt_section_title">Manajemen Konten</string>
-    <string name="misc_section_title">Lain-lain</string>
-    <string name="view_all">Lihat Semua →</string>
-    <string name="import_so_plugin_title">Impor Plugin SO</string>
-    <string name="plugin_name_label">Nama Plugin</string>
-    <string name="plugin_type_label">Jenis</string>
-    <string name="plugin_version_label">Versi</string>
-    <string name="import_button">Impor</string>
-    <string name="settings_subtitle">Konfigurasikan opsi launcher umum</string>
-    <string name="settings_tab_basic">Pengaturan Dasar</string>
-    <string name="settings_tab_personalize">Personalisasi</string>
-    <string name="settings_tab_updates">Pembaruan</string>
-    <string name="settings_tab_about">Tentang</string>
-    <string name="settings_tab_migration">Migrasi</string>
-    <string name="settings_theme_desc">Pilih tema aplikasi</string>
-    <string name="launch_vertically">Luncurkan Vertikal</string>
-    <string name="launch_vertically_desc">Paksa game diluncurkan dalam mode potret</string>
-    <string name="instance_settings_title">Pengaturan Instans</string>
-    <string name="instance_tab_general">Umum</string>
-    <string name="instance_tab_launch_options">Opsi Peluncuran</string>
-    <string name="instance_tab_management">Manajemen</string>
-    <string name="instance_new_name">Nama Baru</string>
-    <string name="instance_rename_hint">Hanya mengganti nama folder. Versi dan jenis game tidak terpengaruh.</string>
-    <string name="instance_custom_icon">Ikon Kustom (harus persegi)</string>
-    <string name="instance_clear_icon">Bersihkan</string>
-    <string name="instance_icon_hint">Akan disimpan sebagai LargeLogo.png di folder versi. Ketuk ikon untuk mengubah.</string>
-    <string name="instance_isolation_desc">Pisahkan data game untuk instans ini. Instans lain tidak akan terpengaruh.</string>
-    <string name="instance_danger_zone">Zona Berbahaya</string>
-    <string name="instance_danger_zone_desc">Tindakan ini memengaruhi pendaftaran instans atau file lokal. Periksa kembali sebelum melanjutkan.</string>
-    <string name="instance_delete_desc">Menghapus instans ini secara permanen dari perangkat, termasuk dunia, konfigurasi, dan konten terpasang.</string>
-    <string name="instance_delete_warning">Tindakan ini tidak dapat dibatalkan.</string>
-    <string name="instance_delete_confirm_title">Hapus Instans</string>
-    <string name="instance_delete_confirm_msg">Apakah Anda yakin ingin menghapus instans ini? Semua data, termasuk dunia, akan dihapus permanen.</string>
-    <string name="instance_batch_backup_button">Cadangkan Massal</string>
-    <string name="instance_batch_backup_title">Cadangkan Instans Massal</string>
-    <string name="instance_batch_backup_select_message">Pilih instans yang ingin dicadangkan. Jika Minecraft sedang berjalan, keluar terlebih dahulu agar data tidak berubah saat pencadangan.</string>
-    <string name="instance_batch_backup_select_all">Pilih semua instans</string>
-    <string name="instance_batch_backup_no_instances">Tidak ada instans yang tersedia untuk dicadangkan.</string>
-    <string name="instance_batch_backup_no_selection">Pilih setidaknya satu instans.</string>
-    <string name="instance_batch_backup_in_progress">Mencadangkan %1$s (%2$d/%3$d)…</string>
-    <string name="instance_batch_backup_success_title">Cadangan Dibuat</string>
-    <string name="instance_batch_backup_success_message">Membuat %1$d cadangan:\n%2$s</string>
-    <string name="instance_batch_backup_partial_title">Pencadangan Selesai Sebagian</string>
-    <string name="instance_batch_backup_partial_message">Membuat %1$d cadangan, %2$d gagal.\n\nTersimpan:\n%3$s\n\nGagal:\n%4$s</string>
-    <string name="instance_batch_backup_failed_title">Pencadangan Massal Gagal</string>
-    <string name="instance_batch_backup_failed_message">Tidak dapat membuat cadangan apa pun:\n%1$s</string>
-    <string name="screenshots_category">Tangkapan Layar</string>
-    <string name="servers_category">Server</string>
-    <string name="saved_to_gallery">Disimpan ke galeri</string>
-    <string name="inbuilt_mod_virtual_cursor">Kursor Virtual</string>
-    <string name="inbuilt_mod_virtual_cursor_desc">Gunakan trackpad virtual untuk mengontrol mouse</string>
-    <string name="virtual_cursor_enabled">Kursor diaktifkan</string>
-    <string name="virtual_cursor_disabled">Kursor dinonaktifkan</string>
-    <string name="cursor_sensitivity_label">Sensitivitas Kursor:</string>
+    <!-- Navigation Bar -->
     <string name="nav_launch">Luncurkan</string>
     <string name="nav_import">Impor</string>
     <string name="nav_instances">Instans</string>
     <string name="nav_about">Tentang</string>
     <string name="nav_settings">Pengaturan</string>
+
     <string name="search_instances_hint">Cari…</string>
     <string name="instances_label">Instans</string>
     <string name="select_instance_title">Pilih Instans</string>
@@ -668,6 +922,7 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="tag_installed">Terinstal</string>
     <string name="tag_custom">Kustom</string>
     <string name="vanilla_prefix">Vanilla %s</string>
+
     <string name="about_page_title">Tentang</string>
     <string name="about_subtitle">LeviLauncher — Launcher Minecraft Bedrock Modern</string>
     <string name="about_authors_title">👥 Penulis &amp; Pemelihara</string>
@@ -684,6 +939,7 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="about_contribute_desc">Kontribusi melalui Issues atau Pull Requests dipersilakan untuk meningkatkan LeviLauncher.</string>
     <string name="about_issues">Issue</string>
     <string name="about_star_fork">Star / Fork</string>
+
     <string-array name="launcher_tips">
         <item>Pengaturan memungkinkan Anda menyesuaikan tema, warna, latar belakang, dan opsi tampilan lain agar sesuai dengan setup Anda.</item>
         <item>LeviLauncher bersifat open source. Gunakan GitHub issues untuk melaporkan masalah launcher atau menyarankan perbaikan.</item>
@@ -697,6 +953,7 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
         <item>CurseForge memungkinkan Anda menjelajahi dan mengunduh konten komunitas secara langsung.</item>
         <item>Muat modul SO native eksternal untuk memperluas atau meningkatkan fitur dan performa Minecraft.</item>
     </string-array>
+    <!-- Personalization -->
     <string name="theme_color_title">Warna Tema</string>
     <string name="theme_color_desc">Warna aksen utama aplikasi</string>
     <string name="preset_colors">WARNA PRESET</string>
@@ -714,163 +971,8 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
 
     <string name="unsupported_version_title">Versi Tidak Didukung</string>
     <string name="unsupported_version_msg">Peluncur ini tidak mendukung versi Minecraft yang lebih lama dari 1.21.80.</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">oleh %s</string>
-    <string name="mod_version_chip">Versi %s</string>
-    <string name="mod_config_title_format">Konfigurasi %s</string>
-    <string name="mod_config_not_found">Tidak ada konfigurasi yang dapat diedit</string>
-    <string name="mod_config_load_failed">Gagal memuat konfigurasi: %s</string>
-    <string name="mod_config_save_failed">Gagal menyimpan konfigurasi</string>
-    <string name="mod_config_saved">Konfigurasi disimpan</string>
-    <string name="mod_config_restart_hint">File konfigurasi disimpan dan file .backup dipertahankan.</string>
-    <string name="mod_config_validation_failed">Validasi konfigurasi gagal</string>
-    <string name="mod_config_invalid_json">JSON tidak valid</string>
-    <string name="mod_config_expand">Buka</string>
-    <string name="mod_config_collapse">Tutup</string>
-    <string name="mod_config_raw_json">Edit JSON asli</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">Item %1$s</string>
-    <string name="mod_config_object_desc">Grup pengaturan terkait</string>
-    <string name="mod_config_array_desc">Daftar nilai</string>
-    <string name="mod_config_range_prefix">Rentang</string>
-    <string name="mod_config_error_number">%1$s harus berupa angka</string>
-    <string name="mod_config_error_minimum">%1$s minimal harus %2$s</string>
-    <string name="mod_config_error_maximum">%1$s maksimal harus %2$s</string>
-    <string name="mod_config_error_boolean">%1$s harus aktif atau nonaktif</string>
-    <string name="mod_config_error_string">%1$s harus berupa teks</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d konfigurasi dapat diedit</item>
-        <item quantity="other">%d konfigurasi dapat diedit</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d pilihan</item>
-        <item quantity="other">%d pilihan</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d item</item>
-        <item quantity="other">%d item</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Favorit</string>
-    <string name="mod_menu_favorite">Tambahkan ke favorit</string>
-    <string name="mod_menu_unfavorite">Hapus dari favorit</string>
-    <string name="mod_menu_hud_editor">Editor HUD</string>
-    <string name="mod_menu_filter_enabled">Aktif</string>
-    <string name="mod_menu_filter_inbuilt">Bawaan</string>
-    <string name="mod_menu_filter_external">Eksternal</string>
-    <string name="mod_menu_no_favorites">Belum ada mod favorit</string>
-    <string name="mod_menu_no_matches">Tidak ada mod yang cocok</string>
-    <string name="mod_menu_group_inbuilt">Fitur Bawaan</string>
-    <string name="mod_menu_group_external_ungrouped">Mod Eksternal Tidak Dikelompokkan</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Pengaturan Umum</string>
-    <string name="mod_menu_appearance">Tampilan</string>
-    <string name="mod_menu_pause_menu_only">Hanya Menu Jeda</string>
-    <string name="mod_menu_pause_menu_only_desc">Tampilkan menu mod hanya di layar jeda</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Ukuran Tombol Overlay (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Opasitas Overlay (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensitivitas Kursor (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Level Zoom (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Keybind Sprint Otomatis</string>
-    <string name="mod_config_zoom_keybind">Keybind Zoom</string>
-    <string name="mod_config_press_any_key">Tekan tombol apa saja untuk mengikat...</string>
-    <string name="mod_config_key_unknown">TIDAK DIKETAHUI</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Ukuran: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Opasitas: %1$d%%</string>
-    <string name="reset">Reset</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Hapus Akun</string>
-    <string name="delete_account_confirm">Yakin ingin menghapus akun ini?</string>
-    <string name="instance_backup_title">Cadangkan Instans</string>
-    <string name="instance_backup_desc">Buat cadangan lengkap instans ini di Download/LeviLauncher/Backups.</string>
-    <string name="instance_backup_button">Cadangkan Instans</string>
-    <string name="instance_backup_confirm_message">Buat cadangan lengkap instans ini sekarang? Tutup Minecraft terlebih dahulu jika sedang berjalan agar file tidak berubah selama pencadangan.</string>
-    <string name="instance_backup_in_progress">Mencadangkan instans…</string>
-    <string name="instance_backup_success_title">Cadangan Dibuat</string>
-    <string name="instance_backup_success_message">Cadangan disimpan ke:\n%1$s</string>
-    <string name="instance_backup_failed_title">Pencadangan Gagal</string>
-    <string name="instance_backup_failed_message">Tidak dapat membuat cadangan:\n%1$s</string>
-    <string name="instance_import_backup_button">Impor Cadangan</string>
-    <string name="instance_restore_title">Pulihkan Cadangan</string>
-    <string name="instance_restore_in_progress">Memulihkan cadangan instans…</string>
-    <string name="instance_restore_success_title">Pemulihan Selesai</string>
-    <string name="instance_restore_success_message">Dipulihkan: %1$s</string>
-    <string name="instance_restore_failed_title">Pemulihan Gagal</string>
-    <string name="instance_restore_failed_message">Tidak dapat memulihkan cadangan:\n%1$s</string>
-    <string name="mod_icon_content_description">Ikon mod</string>
-    <string name="mod_metadata_title">Informasi</string>
-    <string name="mod_actions_title">Tindakan</string>
-    <string name="mod_author_label">Pembuat</string>
-    <string name="mod_version_label">Versi</string>
-    <string name="mod_minecraft_versions_label">Versi Minecraft</string>
-    <string name="mod_entry_label">File Entri</string>
-    <string name="mod_id_label">ID Mod</string>
-    <string name="mod_config_files_label">File Konfigurasi</string>
-    <string name="mod_unknown_author">Pembuat tidak diketahui</string>
-    <string name="mod_unknown_version">Versi tidak diketahui</string>
-    <string name="mod_all_versions">Semua versi yang didukung</string>
-    <string name="mod_no_config_files">Tidak ada konfigurasi yang dapat diedit</string>
-    <string name="mod_config_badge">KONFIG</string>
-    <string name="mod_config_badge_with_count">KONFIG · %d</string>
-    <string name="ms_login_header_subtitle">Masuk ke Minecraft dengan aman</string>
-    <string name="ms_login_retrying">Koneksi terputus. Mencoba ulang dengan aman…</string>
-    <string name="ms_choose_login_method">Masuk ke Minecraft</string>
-    <string name="ms_choose_login_method_desc">Pilih alur kode perangkat berbasis browser atau lanjutkan dengan halaman Microsoft tertanam.</string>
-    <string name="ms_device_code_login">Lanjutkan dengan browser</string>
-    <string name="ms_device_code_option_title">Kode Perangkat (Disarankan)</string>
-    <string name="ms_device_code_login_desc">Buka sesi browser privat dengan kode perangkat yang sudah terisi.</string>
-    <string name="ms_webview_login">Buka masuk tertanam</string>
-    <string name="ms_webview_option_title">WebView Tertanam</string>
-    <string name="ms_webview_login_desc">Masuk tanpa meninggalkan LeviLauncher. Gunakan saat alur browser tidak tersedia.</string>
-    <string name="ms_device_code_title">Masuk dengan Kode Perangkat</string>
-    <string name="ms_device_code_instructions">Buka halaman masuk perangkat Microsoft, masukkan kode ini, lalu setujui akses. LeviLauncher akan menyelesaikannya secara otomatis.</string>
-    <string name="ms_device_code_label">Kode perangkat Microsoft</string>
-    <string name="ms_device_code_requesting">Meminta kode aman…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Menunggu Anda menyelesaikannya di browser…</string>
-    <string name="ms_device_code_checking">Memeriksa hasil masuk Microsoft…</string>
-    <string name="ms_device_code_reconnecting">Koneksi berubah. Mencoba ulang secara otomatis…</string>
-    <string name="ms_device_code_authorized">Microsoft menyetujui proses masuk. Menyelesaikan…</string>
-    <string name="ms_device_code_browser_opened">Selesaikan proses masuk Microsoft yang baru di browser, lalu kembali ke sini.</string>
-    <string name="ms_device_code_expires">Kode kedaluwarsa dalam %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Salin Kode</string>
-    <string name="ms_device_code_copied">Kode disalin</string>
-    <string name="ms_device_code_open_browser">Buka masuk Microsoft</string>
-    <string name="ms_device_code_step_title">Selesaikan proses masuk di browser Anda</string>
-    <string name="ms_device_code_browser_note">LeviLauncher membuka browser default Anda dalam sesi privat, mengisi kode secara otomatis, dan meminta proses masuk Microsoft yang baru.</string>
-    <string name="ms_choose_other_method">Metode lain</string>
-    <string name="ms_no_browser">Tidak ada browser yang tersedia di perangkat ini.</string>
-    <string name="ms_default_browser_no_private_mode">Browser default Anda tidak mendukung masuk secara privat. Perbarui browser atau gunakan login WebView.</string>
-    <string name="ms_login_ssl_failed">Halaman masuk Microsoft yang aman tidak dapat diverifikasi.</string>
-    <string name="ms_login_state_failed">Respons masuk Microsoft tidak dapat diverifikasi. Mulai proses masuk lagi.</string>
-    <string name="ms_login_missing_code">Microsoft tidak mengembalikan kode masuk. Mulai proses masuk lagi atau gunakan login Kode Perangkat.</string>
-    <string name="ms_feature_disabled_title">Fitur Dinonaktifkan</string>
-    <string name="ms_feature_disabled_desc">Aktifkan “Masuk ke Minecraft dengan LeviLauncher” di Pengaturan untuk mengelola akun Microsoft.</string>
-    <string name="ms_activated">Diaktifkan</string>
-    <string name="inbuilt_mod_gyro">Giroskop</string>
-    <string name="inbuilt_mod_gyro_desc">Gunakan giroskop perangkat untuk mengontrol rotasi kamera</string>
-    <string name="inbuilt_mod_pojav_controls">Kontrol Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Ganti kontrol sentuh Minecraft dengan kontrol gaya Pojav yang sepenuhnya dapat disesuaikan</string>
-    <string name="inbuilt_mod_more_buttons">Lebih Banyak Tombol</string>
-    <string name="inbuilt_mod_more_buttons_desc">Buat tombol layar kustom dengan pemetaan satu tombol keyboard dan ikon SVG</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Tampilkan di Mana Saja</string>
-    <string name="mod_config_zoom_transition">Durasi Transisi (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensitivitas Horizontal (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensitivitas Vertikal (%)</string>
-    <string name="mod_config_gyro_invert_x">Balik Sumbu Horizontal</string>
-    <string name="mod_config_gyro_invert_y">Balik Sumbu Vertikal</string>
-    <string name="mod_config_gyro_deadzone">Zona Mati</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Tutup</string>
     <string name="previous">Sebelumnya</string>
     <string name="next">Berikutnya</string>
@@ -920,6 +1022,8 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="custom_color_hint">#RRGGBB atau R,G,B</string>
     <string name="screenshot_name_placeholder">Nama Tangkapan Layar</string>
     <string name="screenshot_date_placeholder">Tanggal: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Buat tombol layar bergaya Minecraft yang masing-masing dipetakan ke tepat satu tombol keyboard. Tombol tidak pernah menjalankan makro, urutan tombol, pengulangan otomatis, atau autoclick.</string>
     <string name="more_buttons_add_button">Tambah Tombol</string>
     <string name="more_buttons_limit_reached">Batas maksimum %1$d tombol kustom telah tercapai.</string>
@@ -977,99 +1081,17 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="more_buttons_no_svg_selected">Tidak ada SVG yang dipilih</string>
     <string name="more_buttons_default_name">Tombol</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Slot Hotbar</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Menambahkan tombol 1–9 terpisah untuk memilih slot hotbar</string>
     <string name="hotbar_slot_content_description">Slot hotbar %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Pintasan Layar Utama</string>
-    <string name="instance_shortcut_desc">Perubahan nama dan ikon disimpan otomatis. Ketuk Tambah Pintasan untuk membuat atau memperbarui pintasan layar utama.</string>
-    <string name="instance_shortcut_name">Nama Pintasan</string>
-    <string name="instance_shortcut_icon">Ikon Pintasan</string>
-    <string name="instance_shortcut_choose_icon">Pilih Ikon</string>
-    <string name="instance_shortcut_default_icon">Gunakan Bawaan</string>
-    <string name="instance_shortcut_add_button">Tambah Pintasan</string>
-    <string name="instance_settings_auto_save_failed">Tidak dapat menyimpan pengaturan instans ini.</string>
-    <string name="instance_shortcut_not_supported">Peluncur layar utama Anda tidak mendukung pintasan yang disematkan.</string>
-    <string name="instance_shortcut_missing">Instans Minecraft ini sudah tidak tersedia.</string>
-    <string name="custom_flat_world_subtitle">Buat dunia dengan bioma dan lapisan blok pilihan Anda sendiri</string>
-    <string name="world_settings">Pengaturan Dunia</string>
-    <string name="world_settings_hint">Pilih pengaturan dasar untuk dunia baru</string>
-    <string name="layers_title">Lapisan</string>
-    <string name="add_layer_compact">Tambah Lapisan</string>
-    <string name="no_layers_title">Belum ada lapisan</string>
-    <string name="no_layers_hint">Tambahkan setidaknya satu lapisan blok untuk membuat dunia</string>
-    <string name="reorder_layer">Susun ulang lapisan</string>
-    <string name="delete_layer">Hapus lapisan</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Pindai</string>
-    <string name="scan_downloads_scanning">Memindai…</string>
-    <string name="scan_downloads_none_found">Tidak ada mod .levipack atau .so yang ditemukan di Unduhan</string>
-    <string name="scan_downloads_failed">Tidak dapat memindai Unduhan</string>
-    <string name="scan_downloads_permission_denied">Akses penyimpanan diperlukan untuk memindai Unduhan</string>
-    <string name="scan_downloads_results_title">Mod di Unduhan</string>
-    <string name="scan_downloads_results_subtitle">Pilih mod untuk ditambahkan. Pemindaian hanya memeriksa folder utama Unduhan.</string>
-    <string name="scan_downloads_add">Tambah</string>
-    <string name="scan_downloads_adding">Menambahkan…</string>
-    <string name="scan_downloads_added">Ditambahkan</string>
-    <string name="scan_downloads_added_message">%1$s ditambahkan</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Pustaka native</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Mod Eksternal</string>
-    <string name="external_mods_subtitle">Mod komunitas untuk Minecraft %1$s</string>
-    <string name="external_mods_no_version">Pilih versi Minecraft sebelum memasang mod</string>
-    <string name="external_mods_search_hint">Cari mod, pembuat, atau versi…</string>
-    <string name="external_mods_compatible_only">Hanya yang kompatibel</string>
-    <string name="external_mods_all_versions">Semua versi Minecraft</string>
-    <string name="external_mods_sort_newest">Terbaru</string>
-    <string name="external_mods_sort_name">Nama A–Z</string>
-    <string name="external_mods_empty">Tidak ada mod yang cocok dengan filter ini</string>
-    <string name="external_mods_load_failed">Tidak dapat menyegarkan katalog. Menampilkan salinan yang tersimpan.</string>
-    <string name="external_mods_refresh">Segarkan katalog</string>
-    <string name="external_mods_refreshed">Katalog disegarkan</string>
-    <string name="external_mods_join_discord">Gabung Discord Komunitas</string>
-    <string name="external_mods_discord_open_failed">Tidak ada aplikasi yang dapat membuka undangan Discord</string>
-    <string name="external_mods_download">Mengunduh %1$s</string>
-    <string name="external_mods_importing">Mengimpor mod…</string>
-    <string name="external_mods_installed">%1$s terpasang</string>
-    <string name="external_mods_install_failed">Tidak dapat memasang %1$s: %2$s</string>
-    <string name="external_mods_open_failed">Tidak ada browser yang dapat membuka unduhan ini</string>
-    <string name="external_mods_direct_download">Unduhan langsung</string>
-    <string name="external_mods_ad_download">Unduhan dengan iklan</string>
-    <string name="external_mods_external_link">Tautan eksternal</string>
-    <string name="external_mods_open_link">Buka Tautan</string>
-    <string name="external_mods_external_dialog_title">Unduhan Eksternal</string>
-    <string name="external_mods_ad_dialog_title">Unduhan dengan Iklan</string>
-    <string name="external_mods_external_dialog_message">%1$s menggunakan halaman unduhan di luar LeviLauncher.\n\n1. Ketuk Buka Tautan dan unduh file .levipack atau .so.\n2. Kembali ke LeviLauncher dan buka Mod.\n3. Ketuk Pindai.\n4. Ketuk Tambah di sebelah mod yang ingin Anda impor.\n\nPemindaian hanya memeriksa folder utama Unduhan. Pindahkan file ke sana jika browser menyimpannya di tempat lain.</string>
-    <string name="external_mods_ad_dialog_message">%1$s menggunakan halaman unduhan dengan iklan yang dipilih oleh pengembangnya. LeviLauncher tidak mengontrol halaman tersebut atau iklannya.\n\n1. Ketuk Buka Tautan dan unduh file .levipack atau .so.\n2. Kembali ke LeviLauncher dan buka Mod.\n3. Ketuk Pindai.\n4. Ketuk Tambah di sebelah mod yang ingin Anda impor.\n\nPemindaian hanya memeriksa folder utama Unduhan. Unduh hanya file mod; jangan memasang aplikasi yang tidak terkait atau mengizinkan notifikasi.</string>
-    <string name="external_mods_by_author">oleh %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Perbarui</string>
-    <string name="external_mods_installed_button">Terpasang</string>
-    <string name="external_mods_incompatible">Tidak kompatibel</string>
-    <string name="foreground_service">Layanan latar depan</string>
-    <string name="foreground_service_desc">Biarkan Minecraft tetap berjalan saat Anda berpindah aplikasi dengan mencegah Bedrock menangguhkan sesi aktif serta menjaga proses, CPU, dan Wi-Fi tetap aktif.</string>
-    <string name="foreground_service_warning">Catatan: Dapat membuat ponsel lebih cepat panas dan meningkatkan penggunaan baterai.</string>
-    <string name="foreground_service_channel">Perlindungan Minecraft di latar belakang</string>
-    <string name="foreground_service_notification_title">Minecraft tetap dijaga aktif</string>
-    <string name="foreground_service_notification_text">Mode latar belakang Minecraft aktif. CPU dan akses jaringan tetap tersedia untuk sesi saat ini.</string>
-    <string name="mod_menu_compact">Menu Mod Ringkas</string>
-    <string name="mod_menu_compact_desc">Gunakan menu yang lebih kecil dengan daftar modul yang padat dan filter ringkas</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Pengali Sensitivitas (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Kecepatan Horizontal (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Kecepatan Vertikal (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Filter Gerakan Kecil (0 = Nonaktif)</string>
-    <string name="hud_editor_drag_hint">Seret untuk memindahkan panel</string>
-    <string name="hud_editor_drag_description">Editor HUD. Seret area ini untuk memindahkan panel.</string>
     <string name="mod_config_hotbar_item_icons">Gunakan ikon item dari hotbar</string>
     <string name="mod_config_hotbar_item_counts">Tampilkan jumlah item</string>
     <string name="mod_config_hotbar_slot_enabled">Tampilkan slot hotbar %1$d</string>
     <string name="mod_config_hotbar_slot_size">Ukuran slot hotbar %1$d (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Opasitas slot hotbar %1$d</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Yang baru</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Lanjutkan</string>
@@ -1092,6 +1114,7 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="mod_config_category_button">Tombol</string>
     <string name="mod_config_visible_slots">Slot Terlihat</string>
     <string name="mod_config_hotbar_slot_section">Slot Hotbar %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Pilih</string>
     <string name="select_all">Pilih Semua</string>
     <string name="selected">Dipilih</string>

--- a/app/src/main/res/values-idn/strings.xml
+++ b/app/src/main/res/values-idn/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Untuk menginstal atau memperbarui aplikasi ini, mohon berikan izin untuk menginstal aplikasi yang tidak dikenal. Klik "Izinkan" untuk membuka pengaturan sistem, aktifkan izin untuk aplikasi ini, dan kembali untuk melanjutkan.</string>
 
     <string name="check_update">Periksa pembaruan</string>
-    <string name="version_prefix">Versi:</string>
+    <string name="version_prefix">Versi: </string>
     <string name="unknown_error">Kesalahan tidak diketahui</string>
     <string name="preloader_sigs_title">Data runtime</string>
     <string name="preloader_sigs_last_update">Pembaruan terakhir: %1$s</string>
@@ -452,7 +452,7 @@ Migrasi harus selesai sebelum LeviLauncher dapat melanjutkan.</string>
     <string name="genuine_badge_label">Lisensi tidak ter-verifikasi</string>
     <string name="invalid_license_detected_toast">Minecraft palsu terdeteksi. Pastikan Minecraft Anda berasal dari Google Play Store.</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Total Mods:</string>
     <string name="enabled_mods">Aktif:</string>
     <string name="add_mod">Tambahkan Mod</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">このアプリをインストールまたは更新するには、提供元不明のアプリのインストールを許可してください。</string>
 
     <string name="check_update">アップデートを確認</string>
-    <string name="version_prefix">バージョン:</string>
+    <string name="version_prefix">バージョン: </string>
     <string name="unknown_error">不明なエラー</string>
     <string name="preloader_sigs_title">ランタイムデータ</string>
     <string name="preloader_sigs_last_update">最終更新: %1$s</string>
@@ -452,7 +452,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="genuine_badge_label">ライセンス未確認</string>
     <string name="invalid_license_detected_toast">非正規品が検出されました。Play ストアからの Minecraft であることを確認してください。</string>
 
-    <string name="full_mods_title">モッド</string>
+    <string name="full_mods_title">モッド </string>
     <string name="total_mods">合計モッド数:</string>
     <string name="enabled_mods">有効化:</string>
     <string name="add_mod">モッドを追加</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -69,6 +76,7 @@
     <string name="files_processed">%d 個のモッドファイルの処理に成功しました</string>
     <string name="user_cancelled">ユーザーによりインポートがキャンセルされました</string>
 
+
     <string name="exit">終了</string>
 
     <string name="overlay_permission_message">オーバーレイ権限を付与してください</string>
@@ -103,11 +111,12 @@
     <string name="settings_tab_migration">移行</string>
     <string name="settings_theme_desc">アプリのテーマを選択</string>
 
+
     <string name="unknown_sources_permission_title">インストールの許可</string>
     <string name="unknown_sources_permission_message">このアプリをインストールまたは更新するには、提供元不明のアプリのインストールを許可してください。</string>
 
     <string name="check_update">アップデートを確認</string>
-    <string name="version_prefix">バージョン: </string>
+    <string name="version_prefix">バージョン:</string>
     <string name="unknown_error">不明なエラー</string>
     <string name="preloader_sigs_title">ランタイムデータ</string>
     <string name="preloader_sigs_last_update">最終更新: %1$s</string>
@@ -131,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">バージョン分離が有効な状態でインストール済みバージョンを起動しようとしています。続行するには無効にしてください。</string>
     <string name="dialog_positive_disable">無効にする</string>
     <string name="dialog_positive_ok">OK</string>
+    <string name="delete_account_title">アカウントを削除</string>
+    <string name="delete_account_confirm">このアカウントを削除してもよろしいですか？</string>
+
 
     <string name="new_version_found">新しいバージョンが見つかりました: %1$s</string>
     <string name="update_question">最新バージョンをダウンロードしてインストールしますか？</string>
@@ -158,6 +170,7 @@
     <string name="repair_preparing">準備中…</string>
     <string name="repair_processing">ライブラリを展開中…</string>
     <string name="repair_finalizing">修復を完了しています…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">ストレージ移行が必要です</string>
     <string name="storage_migration_message">LeviLauncher を続行する前に、games/org.levimc のデータを %1$s に移行する必要があります。
 
@@ -202,21 +215,21 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="shared_storage_layout_mode_legacy">元の internal/external ディレクトリ</string>
     <string name="shared_storage_layout_status">現在のモード: %1$s\nInternal: %2$s\nExternal: %3$s</string>
     <string name="shared_storage_layout_changed">ストレージディレクトリの選択を更新しました。変更を完全に反映するには Minecraft を再起動し、コンテンツ管理を開き直してください。</string>
-
+    <!-- Theme -->
     <string name="theme_title">テーマモード</string>
     <string name="theme_follow_system">システムに従う</string>
     <string name="theme_light">ライトモード</string>
     <string name="theme_dark">ダークモード</string>
 
     <string name="error_no_browser">利用可能なブラウザがありません</string>
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher 使用許諾契約</string>
     <string name="eula_message"><b>LeviLauncher へようこそ</b>\n\nこのソフトウェアを使用することにより、以下に同意したとみなされます：\n\n• これは<b>非公式</b>の Minecraft ランチャーです\n• <b>ライセンスされた</b> Minecraft のコピーを所有している必要があります\n• いかなる形式の海賊版やチートも禁止されています\n• モッドやリソースパックの使用は自己責任です\n• Mojang / Microsoft とは提携していません\n\n継続使用は同意を構成します</string>
     <string name="eula_agree">同意する</string>
     <string name="eula_exit">拒否する</string>
 
     <string name="allow_unknown_sources">続行する前に、提供元不明のアプリのインストールを許可してください</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">バージョンの削除</string>
     <string name="dialog_message_delete_version">このカスタムバージョンを削除してもよろしいですか？この操作は元に戻せません。</string>
     <string name="dialog_positive_delete">削除</string>
@@ -236,7 +249,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="version_isolation">バージョン分離</string>
     <string name="launch_vertically">縦画面で起動</string>
     <string name="launch_vertically_desc">強制的に縦画面モードでゲームを起動する</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">インスタンスの設定</string>
     <string name="instance_tab_general">一般</string>
     <string name="instance_tab_launch_options">起動オプション</string>
@@ -247,12 +260,32 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="instance_clear_icon">クリア</string>
     <string name="instance_icon_hint">バージョンフォルダ下に LargeLogo.png として保存されます。アイコンをタップして変更します。</string>
     <string name="instance_isolation_desc">このインスタンスのゲームデータを分離します。他のインスタンスには影響しません。</string>
+    <string name="instance_shortcut_title">ホーム画面のショートカット</string>
+    <string name="instance_shortcut_desc">名前とアイコンの変更は自動的に保存されます。［ショートカットを追加］をタップすると、ホーム画面のショートカットを作成または更新できます。</string>
+    <string name="instance_shortcut_name">ショートカット名</string>
+    <string name="instance_shortcut_icon">ショートカットアイコン</string>
+    <string name="instance_shortcut_choose_icon">アイコンを選択</string>
+    <string name="instance_shortcut_default_icon">デフォルトを使用</string>
+    <string name="instance_shortcut_add_button">ショートカットを追加</string>
+    <string name="instance_settings_auto_save_failed">このインスタンス設定を保存できませんでした。</string>
+    <string name="instance_shortcut_not_supported">お使いのホームランチャーは固定ショートカットに対応していません。</string>
+    <string name="instance_shortcut_missing">この Minecraft インスタンスは利用できなくなりました。</string>
     <string name="instance_danger_zone">危険ゾーン</string>
     <string name="instance_danger_zone_desc">これらの操作は、インスタンスの登録またはローカルファイルに影響します。</string>
     <string name="instance_delete_desc">このインスタンスをデバイスから完全に削除します（ワールド、設定を含む）。</string>
     <string name="instance_delete_warning">この操作は元に戻せません。</string>
     <string name="instance_delete_confirm_title">インスタンスの削除</string>
     <string name="instance_delete_confirm_msg">本当に削除しますか？ワールドを含むすべてのデータが完全に失われます。</string>
+    <string name="instance_backup_title">インスタンスのバックアップ</string>
+    <string name="instance_backup_desc">このインスタンスの完全バックアップを Download/LeviLauncher/Backups に作成します。</string>
+    <string name="instance_backup_button">インスタンスをバックアップ</string>
+    <string name="instance_backup_confirm_message">このインスタンスの完全バックアップを今すぐ作成しますか？ 実行中の場合は、バックアップ中のファイル変更を防ぐため先に Minecraft を終了してください。</string>
+    <string name="instance_backup_in_progress">インスタンスをバックアップしています…</string>
+    <string name="instance_backup_success_title">バックアップを作成しました</string>
+    <string name="instance_backup_success_message">バックアップの保存先:\n%1$s</string>
+    <string name="instance_backup_failed_title">バックアップ失敗</string>
+    <string name="instance_backup_failed_message">バックアップを作成できませんでした:\n%1$s</string>
+    <string name="instance_import_backup_button">バックアップをインポート</string>
     <string name="instance_batch_backup_button">一括バックアップ</string>
     <string name="instance_batch_backup_title">インスタンスを一括バックアップ</string>
     <string name="instance_batch_backup_select_message">バックアップするインスタンスを選択してください。Minecraft が実行中の場合は、バックアップ中のデータ変更を避けるため先に終了してください。</string>
@@ -266,7 +299,16 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="instance_batch_backup_partial_message">%1$d 件のバックアップを作成し、%2$d 件が失敗しました。\n\n保存済み:\n%3$s\n\n失敗:\n%4$s</string>
     <string name="instance_batch_backup_failed_title">一括バックアップに失敗しました</string>
     <string name="instance_batch_backup_failed_message">バックアップを作成できませんでした:\n%1$s</string>
+    <string name="instance_restore_title">バックアップを復元</string>
+    <string name="instance_restore_in_progress">インスタンスのバックアップを復元しています…</string>
+    <string name="instance_restore_success_title">復元完了</string>
+    <string name="instance_restore_success_message">復元しました: %1$s</string>
+    <string name="instance_restore_failed_title">復元失敗</string>
+    <string name="instance_restore_failed_message">バックアップを復元できませんでした:\n%1$s</string>
 
+    <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">言語 (Language)</string>
     <string name="english">英語 (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -280,6 +322,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
+    <!-- Version Rename -->
     <string name="rename_version_title">バージョンの名前変更</string>
     <string name="rename_version_message">このバージョンの新しい名前を入力してください:</string>
     <string name="new_version_name">新しいバージョン名</string>
@@ -288,6 +331,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="rename_failed">名前の変更に失敗しました: %1$s</string>
     <string name="cannot_rename_installed">インストール済みのバージョンは名前変更できません</string>
 
+    <!-- Content Management -->
     <string name="content_management">コンテンツ管理</string>
     <string name="worlds_title">ワールド</string>
     <string name="resource_packs_title">リソースパック</string>
@@ -319,6 +363,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="import_failed">インポートに失敗しました</string>
     <string name="import_addon_success">アドオンをインポートしました: %1$d 個のリソースパック、%2$d 個のビヘイビアパック</string>
 
+    <!-- World Management -->
     <string name="world_size">サイズ: %s</string>
     <string name="world_last_played">最終プレイ: %s</string>
     <string name="import_world">ワールドをインポート</string>
@@ -330,6 +375,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="delete">削除</string>
     <string name="delete_pack">削除</string>
 
+    <!-- Resource Pack Management -->
     <string name="import_resource_pack">リソースパックをインポート</string>
     <string name="import_behavior_pack">ビヘイビアパックをインポート</string>
     <string name="import_skin_pack">スキンパックをインポート</string>
@@ -337,6 +383,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="delete_skin_pack">スキンパックを削除</string>
     <string name="delete_behavior_pack">ビヘイビアパックを削除</string>
 
+    <!-- Content Operations -->
     <string name="confirm_delete_world">このワールドを削除してもよろしいですか？この操作は元に戻せません。</string>
     <string name="confirm_delete_resource_pack">このパックを削除してもよろしいですか？この操作は元に戻せません。</string>
     <string name="confirm_delete_behavior_pack">このパックを削除してもよろしいですか？この操作は元に戻せません。</string>
@@ -351,9 +398,11 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="deleting_screenshot">スクリーンショットを削除中…</string>
     <string name="deleting_server">サーバーを削除中…</string>
 
+    <!-- World Editor -->
     <string name="edit_world">ワールドの編集</string>
     <string name="edit">編集</string>
     <string name="save">保存</string>
+    <string name="reset">リセット</string>
     <string name="saved_to_gallery">ギャラリーに保存しました</string>
     <string name="level_dat_not_found">level.dat が見つかりません</string>
     <string name="no_editable_properties">編集可能なプロパティがありません</string>
@@ -365,6 +414,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="discard_changes_message">未保存の変更があります。破棄しますか？</string>
     <string name="discard">破棄</string>
 
+    <!-- Custom Flat World -->
     <string name="custom_flat_world">カスタムフラットワールド</string>
     <string name="world_name">ワールド名</string>
     <string name="enter_world_name">ワールド名を入力</string>
@@ -377,7 +427,22 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="add_at_least_one_layer">少なくとも1つのレイヤーを追加してください</string>
     <string name="world_created_successfully">ワールドが作成されました</string>
     <string name="failed_to_create_world">ワールドの作成に失敗しました</string>
+    <string name="custom_flat_world_subtitle">独自のバイオームとブロック層でワールドを作成します</string>
+    <string name="world_settings">ワールド設定</string>
+    <string name="world_settings_hint">新しいワールドの基本設定を選択してください</string>
+    <string name="layers_title">レイヤー</string>
+    <string name="add_layer_compact">レイヤーを追加</string>
+    <string name="no_layers_title">レイヤーはまだありません</string>
+    <string name="no_layers_hint">ワールドを作成するには、少なくとも1つのブロックレイヤーを追加してください</string>
+    <string name="reorder_layer">レイヤーを並べ替え</string>
+    <string name="delete_layer">レイヤーを削除</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$dレイヤー • 下 → 上</item>
+        <item quantity="other">%1$dレイヤー • 下 → 上</item>
+    </plurals>
 
+    <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Play ストア版が必要です</string>
     <string name="minecraft_playstore_required_message">このランチャーは Google Play ストアの公式アプリでのみ動作します。</string>
     <string name="buy_minecraft">Minecraft を入手</string>
@@ -387,11 +452,59 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="genuine_badge_label">ライセンス未確認</string>
     <string name="invalid_license_detected_toast">非正規品が検出されました。Play ストアからの Minecraft であることを確認してください。</string>
 
-    <string name="full_mods_title">モッド </string>
+    <string name="full_mods_title">モッド</string>
     <string name="total_mods">合計モッド数:</string>
     <string name="enabled_mods">有効化:</string>
     <string name="add_mod">モッドを追加</string>
+    <string name="scan_downloads">スキャン</string>
+    <string name="scan_downloads_scanning">スキャン中…</string>
+    <string name="scan_downloads_none_found">ダウンロードに .levipack または .so の Mod が見つかりませんでした</string>
+    <string name="scan_downloads_failed">ダウンロードをスキャンできませんでした</string>
+    <string name="scan_downloads_permission_denied">ダウンロードをスキャンするにはストレージへのアクセスが必要です</string>
+    <string name="scan_downloads_results_title">ダウンロード内の Mod</string>
+    <string name="scan_downloads_results_subtitle">追加する Mod を選択してください。スキャン対象はメインのダウンロードフォルダーのみです。</string>
+    <string name="scan_downloads_add">追加</string>
+    <string name="scan_downloads_adding">追加中…</string>
+    <string name="scan_downloads_added">追加済み</string>
+    <string name="scan_downloads_added_message">%1$s を追加しました</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">ネイティブライブラリ</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">外部 Mod</string>
+    <string name="external_mods_subtitle">Minecraft %1$s 向けコミュニティ Mod</string>
+    <string name="external_mods_no_version">Mod をインストールする前に Minecraft のバージョンを選択してください</string>
+    <string name="external_mods_search_hint">Mod、作者、バージョンを検索…</string>
+    <string name="external_mods_compatible_only">互換性ありのみ</string>
+    <string name="external_mods_all_versions">すべての Minecraft バージョン</string>
+    <string name="external_mods_sort_newest">新しい順</string>
+    <string name="external_mods_sort_name">名前 A–Z</string>
+    <string name="external_mods_empty">このフィルターに一致する Mod はありません</string>
+    <string name="external_mods_load_failed">カタログを更新できませんでした。保存済みのコピーを表示します。</string>
+    <string name="external_mods_refresh">カタログを更新</string>
+    <string name="external_mods_refreshed">カタログを更新しました</string>
+    <string name="external_mods_join_discord">コミュニティ Discord に参加</string>
+    <string name="external_mods_discord_open_failed">Discord の招待を開けるアプリがありません</string>
+    <string name="external_mods_download">%1$s をダウンロード中</string>
+    <string name="external_mods_importing">Mod をインポート中…</string>
+    <string name="external_mods_installed">%1$s をインストールしました</string>
+    <string name="external_mods_install_failed">%1$s をインストールできませんでした: %2$s</string>
+    <string name="external_mods_open_failed">このダウンロードを開けるブラウザーがありません</string>
+    <string name="external_mods_direct_download">直接ダウンロード</string>
+    <string name="external_mods_ad_download">広告付きダウンロード</string>
+    <string name="external_mods_external_link">外部リンク</string>
+    <string name="external_mods_open_link">リンクを開く</string>
+    <string name="external_mods_external_dialog_title">外部ダウンロード</string>
+    <string name="external_mods_ad_dialog_title">広告付きダウンロード</string>
+    <string name="external_mods_external_dialog_message">%1$s は LeviLauncher 外部のダウンロードページを使用します。\n\n1. ［リンクを開く］をタップし、.levipack または .so ファイルをダウンロードします。\n2. LeviLauncher に戻り、［Mod］を開きます。\n3. ［スキャン］をタップします。\n4. インポートしたい Mod の横にある［追加］をタップします。\n\nスキャン対象はメインのダウンロードフォルダーのみです。ブラウザーが別の場所に保存した場合は、ファイルをそこへ移動してください。</string>
+    <string name="external_mods_ad_dialog_message">%1$s は開発者が選んだ広告付きダウンロードページを使用します。LeviLauncher はそのページや広告を管理していません。\n\n1. ［リンクを開く］をタップし、.levipack または .so ファイルをダウンロードします。\n2. LeviLauncher に戻り、［Mod］を開きます。\n3. ［スキャン］をタップします。\n4. インポートしたい Mod の横にある［追加］をタップします。\n\nスキャン対象はメインのダウンロードフォルダーのみです。Mod ファイルだけをダウンロードし、無関係なアプリをインストールしたり通知を許可したりしないでください。</string>
+    <string name="external_mods_by_author">作者: %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">更新</string>
+    <string name="external_mods_installed_button">インストール済み</string>
+    <string name="external_mods_incompatible">非対応</string>
 
+    <!-- Mod Detail -->
     <string name="mod_detail_title">モッドの詳細</string>
     <string name="delete_mod">モッドを削除</string>
     <string name="error_loading_mod">モッドの詳細の読み込みエラー</string>
@@ -399,10 +512,63 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="mod_disabled">モッドが無効です</string>
     <string name="mod_filename_format">ファイル: %s</string>
     <string name="mod_enable_status">有効状態</string>
+    <string name="mod_icon_content_description">Mod アイコン</string>
+    <string name="mod_author_byline">by %s</string>
+    <string name="mod_version_chip">バージョン %s</string>
+    <string name="mod_metadata_title">情報</string>
+    <string name="mod_actions_title">操作</string>
+    <string name="mod_author_label">作者</string>
+    <string name="mod_version_label">バージョン</string>
+    <string name="mod_minecraft_versions_label">Minecraft バージョン</string>
+    <string name="mod_entry_label">エントリーファイル</string>
+    <string name="mod_id_label">Mod ID</string>
+    <string name="mod_config_files_label">設定ファイル</string>
+    <string name="mod_unknown_author">不明な作者</string>
+    <string name="mod_unknown_version">不明なバージョン</string>
+    <string name="mod_all_versions">対応しているすべてのバージョン</string>
+    <string name="mod_no_config_files">編集可能な設定はありません</string>
+    <string name="mod_config_badge">設定</string>
+    <string name="mod_config_badge_with_count">設定 · %d</string>
+    <string name="mod_config_title_format">%s の設定</string>
+    <string name="mod_config_not_found">編集可能な設定が見つかりません</string>
+    <string name="mod_config_load_failed">設定の読み込みに失敗しました: %s</string>
+    <string name="mod_config_save_failed">設定の保存に失敗しました</string>
+    <string name="mod_config_saved">設定を保存しました</string>
+    <string name="mod_config_restart_hint">設定ファイルを保存し、.backup ファイルを保持しました。</string>
+    <string name="mod_config_validation_failed">設定の検証に失敗しました</string>
+    <string name="mod_config_invalid_json">無効な JSON</string>
+    <string name="mod_config_expand">展開</string>
+    <string name="mod_config_collapse">折りたたむ</string>
+    <string name="mod_config_raw_json">元の JSON を編集</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">項目 %1$s</string>
+    <string name="mod_config_object_desc">関連設定のグループ</string>
+    <string name="mod_config_array_desc">値のリスト</string>
+    <string name="mod_config_range_prefix">範囲</string>
+    <string name="mod_config_error_number">%1$s は数値である必要があります</string>
+    <string name="mod_config_error_minimum">%1$s は %2$s 以上である必要があります</string>
+    <string name="mod_config_error_maximum">%1$s は %2$s 以下である必要があります</string>
+    <string name="mod_config_error_boolean">%1$s はオンまたはオフである必要があります</string>
+    <string name="mod_config_error_string">%1$s はテキストである必要があります</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d 個の編集可能な設定</item>
+        <item quantity="other">%d 個の編集可能な設定</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d 個の選択肢</item>
+        <item quantity="other">%d 個の選択肢</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d 個の項目</item>
+        <item quantity="other">%d 個の項目</item>
+    </plurals>
 
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">ゲームのバージョンを選択</string>
     <string name="back">戻る</string>
 
+    <!-- Splash -->
     <string name="splash_logo_desc">葉のロゴ</string>
     <string name="minecraft_loading_title">Minecraft を起動中</string>
     <string name="minecraft_loading_subtitle">ネイティブライブラリと有効な Mod を準備しています</string>
@@ -416,6 +582,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="launcher_restart_subtitle">少しお待ちください。まもなくメイン画面に戻ります</string>
     <string name="launcher_restart_status">もう少しです…</string>
 
+    <!-- Accounts & Microsoft Login -->
     <string name="accounts_title">アカウント</string>
     <string name="microsoft_accounts">Microsoft アカウント</string>
     <string name="manage_accounts">アカウントを管理</string>
@@ -426,13 +593,45 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="accounts_active_privilege">サインイン済み</string>
 
     <string name="ms_login_title">Microsoft ログイン</string>
+    <string name="ms_login_header_subtitle">Minecraft に安全にサインイン</string>
     <string name="ms_login_starting">Microsoft ログインを開始しています…</string>
     <string name="ms_login_exchanging">トークンを交換しています…</string>
     <string name="ms_login_auth_xbox_device">Xbox デバイスを認証しています…</string>
     <string name="ms_login_fetch_minecraft_identity">Minecraft ID を取得しています…</string>
+    <string name="ms_login_retrying">接続が中断されました。安全に再試行しています…</string>
     <string name="ms_login_success">%1$s としてサインインしました</string>
     <string name="ms_login_failed">Microsoft ログインに失敗しました</string>
     <string name="ms_login_failed_detail">ログイン失敗: %1$s</string>
+    <string name="ms_choose_login_method">Minecraft にサインイン</string>
+    <string name="ms_choose_login_method_desc">ブラウザーを使うデバイスコード方式を選ぶか、埋め込み Microsoft ページで続行します。</string>
+    <string name="ms_device_code_login">ブラウザーで続行</string>
+    <string name="ms_device_code_option_title">デバイスコード（推奨）</string>
+    <string name="ms_device_code_login_desc">デバイスコードが入力済みのプライベートブラウザーセッションを開きます。</string>
+    <string name="ms_webview_login">埋め込みサインインを開く</string>
+    <string name="ms_webview_option_title">埋め込み WebView</string>
+    <string name="ms_webview_login_desc">LeviLauncher を離れずにサインインします。ブラウザー方式を利用できない場合に使用してください。</string>
+    <string name="ms_device_code_title">デバイスコードでサインイン</string>
+    <string name="ms_device_code_instructions">Microsoft のデバイスサインインページを開き、このコードを入力してアクセスを承認してください。LeviLauncher が自動的に完了します。</string>
+    <string name="ms_device_code_label">Microsoft デバイスコード</string>
+    <string name="ms_device_code_requesting">安全なコードを要求しています…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">ブラウザーでの操作完了を待っています…</string>
+    <string name="ms_device_code_checking">Microsoft サインイン結果を確認しています…</string>
+    <string name="ms_device_code_reconnecting">接続が変わりました。自動で再試行しています…</string>
+    <string name="ms_device_code_authorized">Microsoft がサインインを承認しました。完了処理中…</string>
+    <string name="ms_device_code_browser_opened">ブラウザーで新しい Microsoft サインインを完了してから、ここに戻ってください。</string>
+    <string name="ms_device_code_expires">コードの有効期限: %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">コードをコピー</string>
+    <string name="ms_device_code_copied">コードをコピーしました</string>
+    <string name="ms_device_code_open_browser">Microsoft サインインを開く</string>
+    <string name="ms_device_code_step_title">ブラウザーでサインインを完了</string>
+    <string name="ms_device_code_browser_note">LeviLauncher は既定のブラウザーをプライベートセッションで開き、コードを自動入力して、新しい Microsoft サインインを要求します。</string>
+    <string name="ms_choose_other_method">別の方法</string>
+    <string name="ms_no_browser">この端末で利用できるブラウザーがありません。</string>
+    <string name="ms_default_browser_no_private_mode">既定のブラウザーはプライベートサインインに対応していません。更新するか WebView ログインを使用してください。</string>
+    <string name="ms_login_ssl_failed">安全な Microsoft サインインページを確認できませんでした。</string>
+    <string name="ms_login_state_failed">Microsoft のサインイン応答を確認できませんでした。サインインをやり直してください。</string>
+    <string name="ms_login_missing_code">Microsoft からサインインコードが返されませんでした。サインインをやり直すか、デバイスコードログインを使用してください。</string>
 
     <string name="ms_set_active">アクティブに設定</string>
     <string name="ms_delete">削除</string>
@@ -445,9 +644,14 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="go_to_accounts">アカウント</string>
     <string name="disable_launcher_login_and_continue">閉じる</string>
 
+    <string name="ms_feature_disabled_title">機能が無効です</string>
+    <string name="ms_feature_disabled_desc">Microsoft アカウントを管理するには、設定で「LeviLauncher で Minecraft にサインイン」を有効にしてください。</string>
+    <string name="ms_activated">有効化済み</string>
+
+    <!-- Popup labels -->
     <string name="label_current_account">現在のアカウント</string>
     <string name="label_other_accounts">その他のアカウント</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">アプリがクラッシュしました</string>
     <string name="crash_upload">クラッシュレポートをアップロード</string>
     <string name="crash_details_title">クラッシュの詳細</string>
@@ -466,8 +670,15 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="dialog_message_exit_app">本当に終了してもよろしいですか？</string>
     <string name="dialog_positive_exit">終了</string>
     <string name="show_logcat_overlay">Logcat オーバーレイ</string>
+    <string name="foreground_service">フォアグラウンドサービス</string>
+    <string name="foreground_service_desc">アプリを切り替えても、Bedrock が実行中のセッションを一時停止しないようにし、プロセス、CPU、Wi-Fi を動作状態に保つことで Minecraft を実行し続けます。</string>
+    <string name="foreground_service_warning">注意: 端末が通常より早く熱くなり、バッテリー消費が増える場合があります。</string>
+    <string name="foreground_service_channel">Minecraft バックグラウンド保護</string>
+    <string name="foreground_service_notification_title">Minecraft を動作状態に保っています</string>
+    <string name="foreground_service_notification_text">Minecraft のバックグラウンドモードが有効です。現在のセッションで CPU とネットワークアクセスを利用できる状態に保っています。</string>
     <string name="logcat_live">Logcat: <b>ライブ</b></string>
     <string name="logcat_paused">Logcat: 一時停止中</string>
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">キーワードフィルター</string>
     <string name="logcat_blacklist_hint">ブラックリスト (カンマ区切り)</string>
     <string name="logcat_filter_clear">フィルターをクリア</string>
@@ -479,6 +690,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="logcat_corner_bottom_left">サイズ変更: 左下</string>
     <string name="logcat_corner_bottom_right">サイズ変更: 右下</string>
 
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mods">内蔵モッド</string>
     <string name="inbuilt_mods_title">内蔵モッド</string>
     <string name="inbuilt_mods_subtitle">ネイティブライブラリなしで動作する内部モッド</string>
@@ -487,7 +699,8 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="inbuilt_mod_removed">%s がモッドから削除されました</string>
     <string name="add">追加</string>
     <string name="remove">削除</string>
-
+    
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">クイックドロップ</string>
     <string name="inbuilt_mod_quick_drop_desc">アイテムをすばやく落とす</string>
     <string name="inbuilt_mod_camera">クイック視点</string>
@@ -515,16 +728,25 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="virtual_cursor_enabled">カーソルが有効になりました</string>
     <string name="virtual_cursor_disabled">カーソルが無効になりました</string>
     <string name="cursor_sensitivity_label">カーソルの感度:</string>
+    <string name="inbuilt_mod_gyro">ジャイロ</string>
+    <string name="inbuilt_mod_gyro_desc">端末のジャイロスコープでカメラの回転を操作します</string>
+    <string name="inbuilt_mod_pojav_controls">Pojav コントロール</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Minecraft のタッチ操作を完全にカスタマイズ可能な Pojav 形式の操作に置き換えます</string>
+    <string name="inbuilt_mod_more_buttons">追加ボタン</string>
+    <string name="inbuilt_mod_more_buttons_desc">1キー割り当てと SVG アイコンを使ってカスタム画面ボタンを作成します</string>
     <string name="inbuilt_badge">内蔵</string>
     <string name="autosprint_keybind_label">オートスプリントのキーバインド:</string>
     <string name="autosprint_keybind_press">任意のキーを押してください…</string>
     <string name="configure">構成</string>
     <string name="overlay_button_size">オーバーレイボタンのサイズ</string>
     <string name="overlay_button_opacity">オーバーレイボタンの不透明度</string>
+    <string name="overlay_button_size_value">サイズ: %1$ddp</string>
+    <string name="overlay_button_opacity_value">透明度: %1$d%%</string>
     <string name="overlay_button_lock">位置をロック</string>
     <string name="overlay_button_lock_desc">ドラッグや誤作動を防ぐ</string>
     <string name="settings">設定</string>
 
+    <!-- Extract Structures -->
     <string name="extract_structures">構造物を抽出</string>
     <string name="no_structures_found">このワールドに構造物が見つかりません</string>
     <string name="no_structures_found_title">構造物が見つかりません</string>
@@ -538,15 +760,36 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="structures_found_title">構造物を発見</string>
     <string name="structures_found_count">このワールドで %d 個の構造物が見つかりました</string>
 
+    <!-- Mod Menu -->
     <string name="mod_menu">モッドメニュー</string>
     <string name="mod_menu_modules">モジュール</string>
+    <string name="mod_menu_favorites">お気に入り</string>
+    <string name="mod_menu_favorite">お気に入りに追加</string>
+    <string name="mod_menu_unfavorite">お気に入りから削除</string>
+    <string name="mod_menu_hud_editor">HUD エディター</string>
+    <string name="mod_menu_filter_enabled">有効</string>
+    <string name="mod_menu_filter_inbuilt">内蔵</string>
+    <string name="mod_menu_filter_external">外部</string>
     <string name="mod_menu_search_hint">モッドを検索…</string>
     <string name="mod_menu_no_mods">モッドが追加されていません</string>
+    <string name="mod_menu_no_favorites">お気に入りのModはまだありません</string>
+    <string name="mod_menu_no_matches">一致するModがありません</string>
+    <string name="mod_menu_group_inbuilt">内蔵機能</string>
+    <string name="mod_menu_group_external_ungrouped">未グループの外部Mod</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">一般設定</string>
+    <string name="mod_menu_appearance">外観</string>
+    <string name="mod_menu_pause_menu_only">ポーズメニューのみ</string>
+    <string name="mod_menu_pause_menu_only_desc">ポーズ画面でのみModメニューを表示</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">設定は近日追加予定</string>
     <string name="mod_menu_notifications">通知</string>
     <string name="mod_menu_notifications_desc">モッドを有効にしたときに通知を表示</string>
     <string name="mod_menu_opacity">モッドメニューの不透明度</string>
     <string name="mod_menu_button_opacity">モッドメニューボタンの不透明度</string>
+    <string name="mod_menu_compact">コンパクト Mod メニュー</string>
+    <string name="mod_menu_compact_desc">密度の高いモジュール一覧とコンパクトなフィルターを備えた小さいメニューを使用します</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">モッドメニュー有効</string>
     <string name="mod_menu_disabled">モッドメニュー無効</string>
@@ -555,7 +798,37 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="mod_status_enabled">有効</string>
     <string name="mod_status_disabled">無効</string>
     <string name="mod_notification_enabled">%s が有効になりました</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">オーバーレイボタンサイズ (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">オーバーレイ透明度 (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">常に表示</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">カーソル感度 (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">ズームレベル (%)</string>
+    <string name="mod_config_auto_sprint_keybind">オートスプリントのキー割り当て</string>
+    <string name="mod_config_zoom_keybind">ズームのキー割り当て</string>
+    <string name="mod_config_zoom_transition">切り替え時間 (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">感度倍率 (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">水平速度 (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">垂直速度 (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">小さい動きのフィルター (0 = オフ)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">水平感度 (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">垂直感度 (%)</string>
+    <string name="mod_config_gyro_invert_x">水平軸を反転</string>
+    <string name="mod_config_gyro_invert_y">垂直軸を反転</string>
+    <string name="mod_config_gyro_deadzone">デッドゾーン</string>
+    <string name="mod_config_press_any_key">割り当てるキーを押してください...</string>
+    <string name="mod_config_key_unknown">不明</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">ドラッグしてパネルを移動</string>
+    <string name="hud_editor_drag_description">HUD エディター。この領域をドラッグしてパネルを移動します。</string>
 
+    <!-- Options Editor -->
     <string name="edit_options">オプションの編集</string>
     <string name="options_file_not_found">オプションファイルが見つかりません</string>
     <string name="no_options_found">オプションが見つかりません</string>
@@ -564,6 +837,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="error_loading_options">オプションの読み込みエラー</string>
     <string name="options_saved">オプションが正常に保存されました</string>
 
+    <!-- Quick Launch -->
     <string name="quick_launch_title">クイック起動</string>
     <string name="quick_launch_subtitle">URI を使用して特定のアクションで Minecraft を起動</string>
     <string name="quick_launch_how_to_play">遊び方</string>
@@ -591,6 +865,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="quick_launch_custom_uri">カスタム URI</string>
     <string name="quick_launch_custom_uri_desc">カスタム minecraft:// URI を入力</string>
 
+    <!-- Quick Launch Dialogs -->
     <string name="server_ip_hint">サーバー IP アドレス</string>
     <string name="server_port_hint">ポート (デフォルト: 19132)</string>
     <string name="server_name_hint">サーバー名</string>
@@ -602,6 +877,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="custom_uri_hint">完全な minecraft:// URI を入力。例:\nminecraft://openStore\nminecraft://?showStoreOffer=UUID</string>
     <string name="select_tab">タブを選択:</string>
 
+    <!-- Quick Launch Validation -->
     <string name="server_ip_required">サーバー IP は必須です</string>
     <string name="server_details_required">サーバー名と IP は必須です</string>
     <string name="invalid_port">無効なポート番号</string>
@@ -610,14 +886,17 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="command_required">コマンドは必須です</string>
     <string name="invalid_minecraft_uri">無効な minecraft:// URI</string>
 
+    <!-- Quick Launch Actions -->
     <string name="connect">接続</string>
     <string name="join">参加</string>
     <string name="load">ロード</string>
     <string name="execute">実行</string>
 
+    <!-- Quick Actions Menu -->
     <string name="quick_launch">クイック起動</string>
     <string name="quick_launch_menu_subtitle">URI アクションで起動</string>
 
+    <!-- CurseForge -->
     <string name="curseforge_title">CurseForge</string>
     <string name="curseforge_subtitle">コンテンツを閲覧してダウンロード</string>
     <string name="curseforge_search_hint">コンテンツを検索…</string>
@@ -627,6 +906,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="curseforge_download_failed">ダウンロード失敗</string>
     <string name="curseforge_available_files">利用可能なファイル</string>
 
+    <!-- Navigation Bar -->
     <string name="nav_launch">起動</string>
     <string name="nav_import">インポート</string>
     <string name="nav_instances">インスタンス</string>
@@ -673,7 +953,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
         <item>CurseForge からコミュニティコンテンツを直接ダウンロードできます。</item>
         <item>外部の SO モジュールをロードして、Minecraft の機能とパフォーマンスを向上させます。</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">テーマの色</string>
     <string name="theme_color_desc">アプリのプライマリアクセントカラー</string>
     <string name="preset_colors">プリセットカラー</string>
@@ -691,160 +971,8 @@ LeviLauncher を続行するには移行を完了する必要があります。<
 
     <string name="unsupported_version_title">サポートされていないバージョン</string>
     <string name="unsupported_version_msg">このランチャーは1.21.80より前のMinecraftバージョンをサポートしていません。</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">by %s</string>
-    <string name="mod_version_chip">バージョン %s</string>
-    <string name="mod_config_title_format">%s の設定</string>
-    <string name="mod_config_not_found">編集可能な設定が見つかりません</string>
-    <string name="mod_config_load_failed">設定の読み込みに失敗しました: %s</string>
-    <string name="mod_config_save_failed">設定の保存に失敗しました</string>
-    <string name="mod_config_saved">設定を保存しました</string>
-    <string name="mod_config_restart_hint">設定ファイルを保存し、.backup ファイルを保持しました。</string>
-    <string name="mod_config_validation_failed">設定の検証に失敗しました</string>
-    <string name="mod_config_invalid_json">無効な JSON</string>
-    <string name="mod_config_expand">展開</string>
-    <string name="mod_config_collapse">折りたたむ</string>
-    <string name="mod_config_raw_json">元の JSON を編集</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">項目 %1$s</string>
-    <string name="mod_config_object_desc">関連設定のグループ</string>
-    <string name="mod_config_array_desc">値のリスト</string>
-    <string name="mod_config_range_prefix">範囲</string>
-    <string name="mod_config_error_number">%1$s は数値である必要があります</string>
-    <string name="mod_config_error_minimum">%1$s は %2$s 以上である必要があります</string>
-    <string name="mod_config_error_maximum">%1$s は %2$s 以下である必要があります</string>
-    <string name="mod_config_error_boolean">%1$s はオンまたはオフである必要があります</string>
-    <string name="mod_config_error_string">%1$s はテキストである必要があります</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="other">%d 個の編集可能な設定</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="other">%d 個の選択肢</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="other">%d 個の項目</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">お気に入り</string>
-    <string name="mod_menu_favorite">お気に入りに追加</string>
-    <string name="mod_menu_unfavorite">お気に入りから削除</string>
-    <string name="mod_menu_hud_editor">HUD エディター</string>
-    <string name="mod_menu_filter_enabled">有効</string>
-    <string name="mod_menu_filter_inbuilt">内蔵</string>
-    <string name="mod_menu_filter_external">外部</string>
-    <string name="mod_menu_no_favorites">お気に入りのModはまだありません</string>
-    <string name="mod_menu_no_matches">一致するModがありません</string>
-    <string name="mod_menu_group_inbuilt">内蔵機能</string>
-    <string name="mod_menu_group_external_ungrouped">未グループの外部Mod</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">一般設定</string>
-    <string name="mod_menu_appearance">外観</string>
-    <string name="mod_menu_pause_menu_only">ポーズメニューのみ</string>
-    <string name="mod_menu_pause_menu_only_desc">ポーズ画面でのみModメニューを表示</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">オーバーレイボタンサイズ (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">オーバーレイ透明度 (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">カーソル感度 (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">ズームレベル (%)</string>
-    <string name="mod_config_auto_sprint_keybind">オートスプリントのキー割り当て</string>
-    <string name="mod_config_zoom_keybind">ズームのキー割り当て</string>
-    <string name="mod_config_press_any_key">割り当てるキーを押してください...</string>
-    <string name="mod_config_key_unknown">不明</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">サイズ: %1$ddp</string>
-    <string name="overlay_button_opacity_value">透明度: %1$d%%</string>
-    <string name="reset">リセット</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">アカウントを削除</string>
-    <string name="delete_account_confirm">このアカウントを削除してもよろしいですか？</string>
-    <string name="instance_backup_title">インスタンスのバックアップ</string>
-    <string name="instance_backup_desc">このインスタンスの完全バックアップを Download/LeviLauncher/Backups に作成します。</string>
-    <string name="instance_backup_button">インスタンスをバックアップ</string>
-    <string name="instance_backup_confirm_message">このインスタンスの完全バックアップを今すぐ作成しますか？ 実行中の場合は、バックアップ中のファイル変更を防ぐため先に Minecraft を終了してください。</string>
-    <string name="instance_backup_in_progress">インスタンスをバックアップしています…</string>
-    <string name="instance_backup_success_title">バックアップを作成しました</string>
-    <string name="instance_backup_success_message">バックアップの保存先:\n%1$s</string>
-    <string name="instance_backup_failed_title">バックアップ失敗</string>
-    <string name="instance_backup_failed_message">バックアップを作成できませんでした:\n%1$s</string>
-    <string name="instance_import_backup_button">バックアップをインポート</string>
-    <string name="instance_restore_title">バックアップを復元</string>
-    <string name="instance_restore_in_progress">インスタンスのバックアップを復元しています…</string>
-    <string name="instance_restore_success_title">復元完了</string>
-    <string name="instance_restore_success_message">復元しました: %1$s</string>
-    <string name="instance_restore_failed_title">復元失敗</string>
-    <string name="instance_restore_failed_message">バックアップを復元できませんでした:\n%1$s</string>
-    <string name="mod_icon_content_description">Mod アイコン</string>
-    <string name="mod_metadata_title">情報</string>
-    <string name="mod_actions_title">操作</string>
-    <string name="mod_author_label">作者</string>
-    <string name="mod_version_label">バージョン</string>
-    <string name="mod_minecraft_versions_label">Minecraft バージョン</string>
-    <string name="mod_entry_label">エントリーファイル</string>
-    <string name="mod_id_label">Mod ID</string>
-    <string name="mod_config_files_label">設定ファイル</string>
-    <string name="mod_unknown_author">不明な作者</string>
-    <string name="mod_unknown_version">不明なバージョン</string>
-    <string name="mod_all_versions">対応しているすべてのバージョン</string>
-    <string name="mod_no_config_files">編集可能な設定はありません</string>
-    <string name="mod_config_badge">設定</string>
-    <string name="mod_config_badge_with_count">設定 · %d</string>
-    <string name="ms_login_header_subtitle">Minecraft に安全にサインイン</string>
-    <string name="ms_login_retrying">接続が中断されました。安全に再試行しています…</string>
-    <string name="ms_choose_login_method">Minecraft にサインイン</string>
-    <string name="ms_choose_login_method_desc">ブラウザーを使うデバイスコード方式を選ぶか、埋め込み Microsoft ページで続行します。</string>
-    <string name="ms_device_code_login">ブラウザーで続行</string>
-    <string name="ms_device_code_option_title">デバイスコード（推奨）</string>
-    <string name="ms_device_code_login_desc">デバイスコードが入力済みのプライベートブラウザーセッションを開きます。</string>
-    <string name="ms_webview_login">埋め込みサインインを開く</string>
-    <string name="ms_webview_option_title">埋め込み WebView</string>
-    <string name="ms_webview_login_desc">LeviLauncher を離れずにサインインします。ブラウザー方式を利用できない場合に使用してください。</string>
-    <string name="ms_device_code_title">デバイスコードでサインイン</string>
-    <string name="ms_device_code_instructions">Microsoft のデバイスサインインページを開き、このコードを入力してアクセスを承認してください。LeviLauncher が自動的に完了します。</string>
-    <string name="ms_device_code_label">Microsoft デバイスコード</string>
-    <string name="ms_device_code_requesting">安全なコードを要求しています…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">ブラウザーでの操作完了を待っています…</string>
-    <string name="ms_device_code_checking">Microsoft サインイン結果を確認しています…</string>
-    <string name="ms_device_code_reconnecting">接続が変わりました。自動で再試行しています…</string>
-    <string name="ms_device_code_authorized">Microsoft がサインインを承認しました。完了処理中…</string>
-    <string name="ms_device_code_browser_opened">ブラウザーで新しい Microsoft サインインを完了してから、ここに戻ってください。</string>
-    <string name="ms_device_code_expires">コードの有効期限: %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">コードをコピー</string>
-    <string name="ms_device_code_copied">コードをコピーしました</string>
-    <string name="ms_device_code_open_browser">Microsoft サインインを開く</string>
-    <string name="ms_device_code_step_title">ブラウザーでサインインを完了</string>
-    <string name="ms_device_code_browser_note">LeviLauncher は既定のブラウザーをプライベートセッションで開き、コードを自動入力して、新しい Microsoft サインインを要求します。</string>
-    <string name="ms_choose_other_method">別の方法</string>
-    <string name="ms_no_browser">この端末で利用できるブラウザーがありません。</string>
-    <string name="ms_default_browser_no_private_mode">既定のブラウザーはプライベートサインインに対応していません。更新するか WebView ログインを使用してください。</string>
-    <string name="ms_login_ssl_failed">安全な Microsoft サインインページを確認できませんでした。</string>
-    <string name="ms_login_state_failed">Microsoft のサインイン応答を確認できませんでした。サインインをやり直してください。</string>
-    <string name="ms_login_missing_code">Microsoft からサインインコードが返されませんでした。サインインをやり直すか、デバイスコードログインを使用してください。</string>
-    <string name="ms_feature_disabled_title">機能が無効です</string>
-    <string name="ms_feature_disabled_desc">Microsoft アカウントを管理するには、設定で「LeviLauncher で Minecraft にサインイン」を有効にしてください。</string>
-    <string name="ms_activated">有効化済み</string>
-    <string name="inbuilt_mod_gyro">ジャイロ</string>
-    <string name="inbuilt_mod_gyro_desc">端末のジャイロスコープでカメラの回転を操作します</string>
-    <string name="inbuilt_mod_pojav_controls">Pojav コントロール</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Minecraft のタッチ操作を完全にカスタマイズ可能な Pojav 形式の操作に置き換えます</string>
-    <string name="inbuilt_mod_more_buttons">追加ボタン</string>
-    <string name="inbuilt_mod_more_buttons_desc">1キー割り当てと SVG アイコンを使ってカスタム画面ボタンを作成します</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">常に表示</string>
-    <string name="mod_config_zoom_transition">切り替え時間 (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">水平感度 (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">垂直感度 (%)</string>
-    <string name="mod_config_gyro_invert_x">水平軸を反転</string>
-    <string name="mod_config_gyro_invert_y">垂直軸を反転</string>
-    <string name="mod_config_gyro_deadzone">デッドゾーン</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">閉じる</string>
     <string name="previous">前へ</string>
     <string name="next">次へ</string>
@@ -894,6 +1022,8 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="custom_color_hint">#RRGGBB または R,G,B</string>
     <string name="screenshot_name_placeholder">スクリーンショット名</string>
     <string name="screenshot_date_placeholder">日時: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Minecraft 風の画面ボタンを作成し、それぞれにキーボードの1キーだけを割り当てます。マクロ、キーシーケンス、自動リピート、オートクリックは実行されません。</string>
     <string name="more_buttons_add_button">ボタンを追加</string>
     <string name="more_buttons_limit_reached">カスタムボタンの上限 %1$d 個に達しました。</string>
@@ -951,99 +1081,17 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="more_buttons_no_svg_selected">SVG が選択されていません</string>
     <string name="more_buttons_default_name">ボタン</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">ホットバースロット</string>
     <string name="inbuilt_mod_hotbar_slot_desc">ホットバースロットを選択するための1～9の個別ボタンを追加します</string>
     <string name="hotbar_slot_content_description">ホットバースロット %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">ホーム画面のショートカット</string>
-    <string name="instance_shortcut_desc">名前とアイコンの変更は自動的に保存されます。［ショートカットを追加］をタップすると、ホーム画面のショートカットを作成または更新できます。</string>
-    <string name="instance_shortcut_name">ショートカット名</string>
-    <string name="instance_shortcut_icon">ショートカットアイコン</string>
-    <string name="instance_shortcut_choose_icon">アイコンを選択</string>
-    <string name="instance_shortcut_default_icon">デフォルトを使用</string>
-    <string name="instance_shortcut_add_button">ショートカットを追加</string>
-    <string name="instance_settings_auto_save_failed">このインスタンス設定を保存できませんでした。</string>
-    <string name="instance_shortcut_not_supported">お使いのホームランチャーは固定ショートカットに対応していません。</string>
-    <string name="instance_shortcut_missing">この Minecraft インスタンスは利用できなくなりました。</string>
-    <string name="custom_flat_world_subtitle">独自のバイオームとブロック層でワールドを作成します</string>
-    <string name="world_settings">ワールド設定</string>
-    <string name="world_settings_hint">新しいワールドの基本設定を選択してください</string>
-    <string name="layers_title">レイヤー</string>
-    <string name="add_layer_compact">レイヤーを追加</string>
-    <string name="no_layers_title">レイヤーはまだありません</string>
-    <string name="no_layers_hint">ワールドを作成するには、少なくとも1つのブロックレイヤーを追加してください</string>
-    <string name="reorder_layer">レイヤーを並べ替え</string>
-    <string name="delete_layer">レイヤーを削除</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">スキャン</string>
-    <string name="scan_downloads_scanning">スキャン中…</string>
-    <string name="scan_downloads_none_found">ダウンロードに .levipack または .so の Mod が見つかりませんでした</string>
-    <string name="scan_downloads_failed">ダウンロードをスキャンできませんでした</string>
-    <string name="scan_downloads_permission_denied">ダウンロードをスキャンするにはストレージへのアクセスが必要です</string>
-    <string name="scan_downloads_results_title">ダウンロード内の Mod</string>
-    <string name="scan_downloads_results_subtitle">追加する Mod を選択してください。スキャン対象はメインのダウンロードフォルダーのみです。</string>
-    <string name="scan_downloads_add">追加</string>
-    <string name="scan_downloads_adding">追加中…</string>
-    <string name="scan_downloads_added">追加済み</string>
-    <string name="scan_downloads_added_message">%1$s を追加しました</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">ネイティブライブラリ</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">外部 Mod</string>
-    <string name="external_mods_subtitle">Minecraft %1$s 向けコミュニティ Mod</string>
-    <string name="external_mods_no_version">Mod をインストールする前に Minecraft のバージョンを選択してください</string>
-    <string name="external_mods_search_hint">Mod、作者、バージョンを検索…</string>
-    <string name="external_mods_compatible_only">互換性ありのみ</string>
-    <string name="external_mods_all_versions">すべての Minecraft バージョン</string>
-    <string name="external_mods_sort_newest">新しい順</string>
-    <string name="external_mods_sort_name">名前 A–Z</string>
-    <string name="external_mods_empty">このフィルターに一致する Mod はありません</string>
-    <string name="external_mods_load_failed">カタログを更新できませんでした。保存済みのコピーを表示します。</string>
-    <string name="external_mods_refresh">カタログを更新</string>
-    <string name="external_mods_refreshed">カタログを更新しました</string>
-    <string name="external_mods_join_discord">コミュニティ Discord に参加</string>
-    <string name="external_mods_discord_open_failed">Discord の招待を開けるアプリがありません</string>
-    <string name="external_mods_download">%1$s をダウンロード中</string>
-    <string name="external_mods_importing">Mod をインポート中…</string>
-    <string name="external_mods_installed">%1$s をインストールしました</string>
-    <string name="external_mods_install_failed">%1$s をインストールできませんでした: %2$s</string>
-    <string name="external_mods_open_failed">このダウンロードを開けるブラウザーがありません</string>
-    <string name="external_mods_direct_download">直接ダウンロード</string>
-    <string name="external_mods_ad_download">広告付きダウンロード</string>
-    <string name="external_mods_external_link">外部リンク</string>
-    <string name="external_mods_open_link">リンクを開く</string>
-    <string name="external_mods_external_dialog_title">外部ダウンロード</string>
-    <string name="external_mods_ad_dialog_title">広告付きダウンロード</string>
-    <string name="external_mods_external_dialog_message">%1$s は LeviLauncher 外部のダウンロードページを使用します。\n\n1. ［リンクを開く］をタップし、.levipack または .so ファイルをダウンロードします。\n2. LeviLauncher に戻り、［Mod］を開きます。\n3. ［スキャン］をタップします。\n4. インポートしたい Mod の横にある［追加］をタップします。\n\nスキャン対象はメインのダウンロードフォルダーのみです。ブラウザーが別の場所に保存した場合は、ファイルをそこへ移動してください。</string>
-    <string name="external_mods_ad_dialog_message">%1$s は開発者が選んだ広告付きダウンロードページを使用します。LeviLauncher はそのページや広告を管理していません。\n\n1. ［リンクを開く］をタップし、.levipack または .so ファイルをダウンロードします。\n2. LeviLauncher に戻り、［Mod］を開きます。\n3. ［スキャン］をタップします。\n4. インポートしたい Mod の横にある［追加］をタップします。\n\nスキャン対象はメインのダウンロードフォルダーのみです。Mod ファイルだけをダウンロードし、無関係なアプリをインストールしたり通知を許可したりしないでください。</string>
-    <string name="external_mods_by_author">作者: %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">更新</string>
-    <string name="external_mods_installed_button">インストール済み</string>
-    <string name="external_mods_incompatible">非対応</string>
-    <string name="foreground_service">フォアグラウンドサービス</string>
-    <string name="foreground_service_desc">アプリを切り替えても、Bedrock が実行中のセッションを一時停止しないようにし、プロセス、CPU、Wi-Fi を動作状態に保つことで Minecraft を実行し続けます。</string>
-    <string name="foreground_service_warning">注意: 端末が通常より早く熱くなり、バッテリー消費が増える場合があります。</string>
-    <string name="foreground_service_channel">Minecraft バックグラウンド保護</string>
-    <string name="foreground_service_notification_title">Minecraft を動作状態に保っています</string>
-    <string name="foreground_service_notification_text">Minecraft のバックグラウンドモードが有効です。現在のセッションで CPU とネットワークアクセスを利用できる状態に保っています。</string>
-    <string name="mod_menu_compact">コンパクト Mod メニュー</string>
-    <string name="mod_menu_compact_desc">密度の高いモジュール一覧とコンパクトなフィルターを備えた小さいメニューを使用します</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">感度倍率 (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">水平速度 (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">垂直速度 (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">小さい動きのフィルター (0 = オフ)</string>
-    <string name="hud_editor_drag_hint">ドラッグしてパネルを移動</string>
-    <string name="hud_editor_drag_description">HUD エディター。この領域をドラッグしてパネルを移動します。</string>
     <string name="mod_config_hotbar_item_icons">ホットバーのアイテムアイコンを使用</string>
     <string name="mod_config_hotbar_item_counts">アイテム数を表示</string>
     <string name="mod_config_hotbar_slot_enabled">ホットバースロット %1$d を表示</string>
     <string name="mod_config_hotbar_slot_size">ホットバースロット %1$d のサイズ (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">ホットバースロット %1$d の不透明度</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">新機能</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">続行</string>
@@ -1066,6 +1114,7 @@ LeviLauncher を続行するには移行を完了する必要があります。<
     <string name="mod_config_category_button">ボタン</string>
     <string name="mod_config_visible_slots">表示するスロット</string>
     <string name="mod_config_hotbar_slot_section">ホットバースロット %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">選択</string>
     <string name="select_all">すべて選択</string>
     <string name="selected">選択済み</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -69,6 +76,7 @@
     <string name="files_processed">%d arquivos de mods processados com sucesso</string>
     <string name="user_cancelled">Importação cancelada pelo usuário</string>
 
+
     <string name="exit">Sair</string>
 
     <string name="overlay_permission_message">Por favor, conceda a permissão de sobreposição</string>
@@ -103,11 +111,12 @@
     <string name="settings_tab_migration">Migração</string>
     <string name="settings_theme_desc">Escolha o tema do aplicativo</string>
 
+
     <string name="unknown_sources_permission_title">Permissão de Instalação</string>
     <string name="unknown_sources_permission_message">Para instalar ou atualizar este aplicativo, conceda permissão para instalar fontes desconhecidas.</string>
 
     <string name="check_update">Verificar atualizações</string>
-    <string name="version_prefix">Versão: </string>
+    <string name="version_prefix">Versão:</string>
     <string name="unknown_error">Erro desconhecido</string>
     <string name="preloader_sigs_title">Dados de execução</string>
     <string name="preloader_sigs_last_update">Última atualização: %1$s</string>
@@ -131,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">Desative o isolamento de versão para continuar com esta versão instalada.</string>
     <string name="dialog_positive_disable">Desativar</string>
     <string name="dialog_positive_ok">OK</string>
+    <string name="delete_account_title">Excluir conta</string>
+    <string name="delete_account_confirm">Tem certeza de que deseja excluir esta conta?</string>
+
 
     <string name="new_version_found">Nova versão encontrada: %1$s</string>
     <string name="update_question">Deseja baixar e instalar a versão mais recente?</string>
@@ -158,6 +170,7 @@
     <string name="repair_preparing">Preparando…</string>
     <string name="repair_processing">Extraindo bibliotecas…</string>
     <string name="repair_finalizing">Finalizando reparo…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Migração de Armazenamento Necessária</string>
     <string name="storage_migration_message">O LeviLauncher deve migrar os dados de games/org.levimc para %1$s antes de continuar.
 
@@ -202,21 +215,21 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="shared_storage_layout_mode_legacy">Diretórios internos/externos originais</string>
     <string name="shared_storage_layout_status">Modo atual: %1$s\nInterno: %2$s\nExterno: %3$s</string>
     <string name="shared_storage_layout_changed">A seleção do diretório de armazenamento foi atualizada. Reinicie o Minecraft e reabra o gerenciamento de conteúdo para aplicar totalmente a alteração.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Modo Tema</string>
     <string name="theme_follow_system">Seguir o Sistema</string>
     <string name="theme_light">Modo Claro</string>
     <string name="theme_dark">Modo Escuro</string>
 
     <string name="error_no_browser">Nenhum navegador disponível</string>
-
+    <!-- License & Security -->
     <string name="eula_title">Contrato de Licença LeviLauncher</string>
     <string name="eula_message"><b>Bem-vindo ao LeviLauncher</b>\n\nAo usar este software, você concorda que:\n\n• Este é um launcher <b>não oficial</b>\n• Você deve possuir uma cópia <b>licenciada</b> do Minecraft\n• Qualquer pirataria ou trapaça é proibida\n• O uso de mods/pacotes é por sua conta e risco\n• Não afiliado à Mojang/Microsoft\n\nO uso contínuo constitui concordância</string>
     <string name="eula_agree">Aceitar</string>
     <string name="eula_exit">Recusar</string>
 
     <string name="allow_unknown_sources">Por favor, permita a instalação de fontes desconhecidas antes de continuar.</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Excluir Versão</string>
     <string name="dialog_message_delete_version">Tem certeza de que deseja excluir esta versão personalizada? Esta ação não pode ser desfeita.</string>
     <string name="dialog_positive_delete">Excluir</string>
@@ -236,7 +249,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="version_isolation">Isolamento de Versão</string>
     <string name="launch_vertically">Iniciar Verticalmente</string>
     <string name="launch_vertically_desc">Forçar o jogo a iniciar em modo retrato</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Configurações da Instância</string>
     <string name="instance_tab_general">Geral</string>
     <string name="instance_tab_launch_options">Opções de Início</string>
@@ -247,12 +260,32 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="instance_clear_icon">Limpar</string>
     <string name="instance_icon_hint">Será salvo como LargeLogo.png na pasta da versão. Clique para mudar.</string>
     <string name="instance_isolation_desc">Isolar dados de jogo para esta instância. Outras não serão afetadas.</string>
+    <string name="instance_shortcut_title">Atalho da tela inicial</string>
+    <string name="instance_shortcut_desc">As alterações de nome e ícone são salvas automaticamente. Toque em Adicionar atalho para criar ou atualizar o atalho da tela inicial.</string>
+    <string name="instance_shortcut_name">Nome do atalho</string>
+    <string name="instance_shortcut_icon">Ícone do atalho</string>
+    <string name="instance_shortcut_choose_icon">Escolher ícone</string>
+    <string name="instance_shortcut_default_icon">Usar padrão</string>
+    <string name="instance_shortcut_add_button">Adicionar atalho</string>
+    <string name="instance_settings_auto_save_failed">Não foi possível salvar esta configuração da instância.</string>
+    <string name="instance_shortcut_not_supported">Seu launcher da tela inicial não oferece suporte a atalhos fixados.</string>
+    <string name="instance_shortcut_missing">Esta instância do Minecraft não está mais disponível.</string>
     <string name="instance_danger_zone">Zona de Perigo</string>
     <string name="instance_danger_zone_desc">Essas ações afetam o registro ou os arquivos. Verifique antes de continuar.</string>
     <string name="instance_delete_desc">Exclui permanentemente esta instância do seu dispositivo.</string>
     <string name="instance_delete_warning">Esta ação não pode ser desfeita.</string>
     <string name="instance_delete_confirm_title">Excluir Instância</string>
     <string name="instance_delete_confirm_msg">Tem certeza? Todos os dados (mundos incluídos) serão removidos para sempre.</string>
+    <string name="instance_backup_title">Backup da instância</string>
+    <string name="instance_backup_desc">Crie um backup completo desta instância em Download/LeviLauncher/Backups.</string>
+    <string name="instance_backup_button">Fazer backup da instância</string>
+    <string name="instance_backup_confirm_message">Criar um backup completo desta instância agora? Feche o Minecraft primeiro se ele estiver em execução para evitar alterações nos arquivos durante o backup.</string>
+    <string name="instance_backup_in_progress">Fazendo backup da instância…</string>
+    <string name="instance_backup_success_title">Backup criado</string>
+    <string name="instance_backup_success_message">Backup salvo em:\n%1$s</string>
+    <string name="instance_backup_failed_title">Falha no backup</string>
+    <string name="instance_backup_failed_message">Não foi possível criar o backup:\n%1$s</string>
+    <string name="instance_import_backup_button">Importar backup</string>
     <string name="instance_batch_backup_button">Backup em Lote</string>
     <string name="instance_batch_backup_title">Backup em Lote de Instâncias</string>
     <string name="instance_batch_backup_select_message">Selecione as instâncias para fazer backup. Feche o Minecraft primeiro se ele estiver em execução para evitar alterações de dados durante o backup.</string>
@@ -266,7 +299,16 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="instance_batch_backup_partial_message">%1$d backups criados, %2$d falharam.\n\nSalvos:\n%3$s\n\nFalhas:\n%4$s</string>
     <string name="instance_batch_backup_failed_title">Falha no Backup em Lote</string>
     <string name="instance_batch_backup_failed_message">Não foi possível criar nenhum backup:\n%1$s</string>
+    <string name="instance_restore_title">Restaurar backup</string>
+    <string name="instance_restore_in_progress">Restaurando backup da instância…</string>
+    <string name="instance_restore_success_title">Restauração concluída</string>
+    <string name="instance_restore_success_message">Restaurado: %1$s</string>
+    <string name="instance_restore_failed_title">Falha na restauração</string>
+    <string name="instance_restore_failed_message">Não foi possível restaurar o backup:\n%1$s</string>
 
+    <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Idioma (Language)</string>
     <string name="english">Inglés (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -280,6 +322,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
+    <!-- Version Rename -->
     <string name="rename_version_title">Renomear Versão</string>
     <string name="rename_version_message">Insira um novo nome para esta versão:</string>
     <string name="new_version_name">Novo nome da versão</string>
@@ -288,6 +331,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="rename_failed">Falha ao renomear: %1$s</string>
     <string name="cannot_rename_installed">Não é possível renomear versões instaladas</string>
 
+    <!-- Content Management -->
     <string name="content_management">Gerenciamento de Conteúdo</string>
     <string name="worlds_title">Mundos</string>
     <string name="resource_packs_title">Pacotes de Textura</string>
@@ -319,6 +363,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="import_failed">A importação falhou</string>
     <string name="import_addon_success">Addon importado: %1$d pacote(s) de textura, %2$d pacote(s) de comportamento</string>
 
+    <!-- World Management -->
     <string name="world_size">Tamanho: %s</string>
     <string name="world_last_played">Jogado pela última vez: %s</string>
     <string name="import_world">Importar Mundo</string>
@@ -330,6 +375,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="delete">Excluir</string>
     <string name="delete_pack">Excluir</string>
 
+    <!-- Resource Pack Management -->
     <string name="import_resource_pack">Importar Pacote de Textura</string>
     <string name="import_behavior_pack">Importar Pacote de Comportamento</string>
     <string name="import_skin_pack">Importar Pacote de Skins</string>
@@ -337,6 +383,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="delete_skin_pack">Excluir Pacote de Skins</string>
     <string name="delete_behavior_pack">Excluir Pacote de Comportamento</string>
 
+    <!-- Content Operations -->
     <string name="confirm_delete_world">Deseja realmente excluir este mundo? Essa ação não pode ser desfeita.</string>
     <string name="confirm_delete_resource_pack">Deseja realmente excluir este pacote? Essa ação não pode ser desfeita.</string>
     <string name="confirm_delete_behavior_pack">Deseja realmente excluir este pacote? Essa ação não pode ser desfeita.</string>
@@ -351,9 +398,11 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="deleting_screenshot">Excluindo captura de tela…</string>
     <string name="deleting_server">Excluindo servidor…</string>
 
+    <!-- World Editor -->
     <string name="edit_world">Editar Mundo</string>
     <string name="edit">Editar</string>
     <string name="save">Salvar</string>
+    <string name="reset">Redefinir</string>
     <string name="saved_to_gallery">Salvo na galeria</string>
     <string name="level_dat_not_found">level.dat não encontrado</string>
     <string name="no_editable_properties">Nenhuma propriedade editável</string>
@@ -365,6 +414,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="discard_changes_message">Você tem alterações não salvas. Deseja descartá-las?</string>
     <string name="discard">Descartar</string>
 
+    <!-- Custom Flat World -->
     <string name="custom_flat_world">Mundo Plano Personalizado</string>
     <string name="world_name">Nome do Mundo</string>
     <string name="enter_world_name">Digite o nome do mundo</string>
@@ -377,7 +427,22 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="add_at_least_one_layer">Adicione pelo menos uma camada</string>
     <string name="world_created_successfully">Mundo criado com sucesso</string>
     <string name="failed_to_create_world">Falha ao criar o mundo</string>
+    <string name="custom_flat_world_subtitle">Crie um mundo com seu próprio bioma e camadas de blocos</string>
+    <string name="world_settings">Configurações do mundo</string>
+    <string name="world_settings_hint">Escolha as configurações básicas do novo mundo</string>
+    <string name="layers_title">Camadas</string>
+    <string name="add_layer_compact">Adicionar camada</string>
+    <string name="no_layers_title">Ainda não há camadas</string>
+    <string name="no_layers_hint">Adicione pelo menos uma camada de blocos para criar o mundo</string>
+    <string name="reorder_layer">Reordenar camada</string>
+    <string name="delete_layer">Excluir camada</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d camada • baixo → cima</item>
+        <item quantity="other">%1$d camadas • baixo → cima</item>
+    </plurals>
 
+    <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Versão da Play Store Necessária</string>
     <string name="minecraft_playstore_required_message">Este launcher só funciona com a versão oficial do Minecraft da Google Play. Por favor, instale-a.</string>
     <string name="buy_minecraft">Obter Minecraft</string>
@@ -387,11 +452,59 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="genuine_badge_label">Licença não verificada</string>
     <string name="invalid_license_detected_toast">Minecraft não original detectado. Verifique a sua versão da Play Store.</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Total de Mods:</string>
     <string name="enabled_mods">Ativados:</string>
     <string name="add_mod">Adicionar Mod</string>
+    <string name="scan_downloads">Verificar</string>
+    <string name="scan_downloads_scanning">Verificando…</string>
+    <string name="scan_downloads_none_found">Nenhum mod .levipack ou .so encontrado em Downloads</string>
+    <string name="scan_downloads_failed">Não foi possível verificar Downloads</string>
+    <string name="scan_downloads_permission_denied">É necessário acesso ao armazenamento para verificar Downloads</string>
+    <string name="scan_downloads_results_title">Mods em Downloads</string>
+    <string name="scan_downloads_results_subtitle">Escolha um mod para adicionar. A verificação analisa apenas a pasta principal Downloads.</string>
+    <string name="scan_downloads_add">Adicionar</string>
+    <string name="scan_downloads_adding">Adicionando…</string>
+    <string name="scan_downloads_added">Adicionado</string>
+    <string name="scan_downloads_added_message">%1$s adicionado</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Biblioteca nativa</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Mods externos</string>
+    <string name="external_mods_subtitle">Mods da comunidade para Minecraft %1$s</string>
+    <string name="external_mods_no_version">Selecione uma versão do Minecraft antes de instalar mods</string>
+    <string name="external_mods_search_hint">Pesquisar mods, autores ou versões…</string>
+    <string name="external_mods_compatible_only">Somente compatíveis</string>
+    <string name="external_mods_all_versions">Todas as versões do Minecraft</string>
+    <string name="external_mods_sort_newest">Mais recentes</string>
+    <string name="external_mods_sort_name">Nome A–Z</string>
+    <string name="external_mods_empty">Nenhum mod corresponde a estes filtros</string>
+    <string name="external_mods_load_failed">Não foi possível atualizar o catálogo. Exibindo a cópia salva.</string>
+    <string name="external_mods_refresh">Atualizar catálogo</string>
+    <string name="external_mods_refreshed">Catálogo atualizado</string>
+    <string name="external_mods_join_discord">Entrar no Discord da comunidade</string>
+    <string name="external_mods_discord_open_failed">Nenhum aplicativo pode abrir o convite do Discord</string>
+    <string name="external_mods_download">Baixando %1$s</string>
+    <string name="external_mods_importing">Importando mod…</string>
+    <string name="external_mods_installed">%1$s instalado</string>
+    <string name="external_mods_install_failed">Não foi possível instalar %1$s: %2$s</string>
+    <string name="external_mods_open_failed">Nenhum navegador pode abrir este download</string>
+    <string name="external_mods_direct_download">Download direto</string>
+    <string name="external_mods_ad_download">Download com anúncios</string>
+    <string name="external_mods_external_link">Link externo</string>
+    <string name="external_mods_open_link">Abrir link</string>
+    <string name="external_mods_external_dialog_title">Download externo</string>
+    <string name="external_mods_ad_dialog_title">Download com anúncios</string>
+    <string name="external_mods_external_dialog_message">%1$s usa uma página de download fora do LeviLauncher.\n\n1. Toque em Abrir link e baixe o arquivo .levipack ou .so.\n2. Volte ao LeviLauncher e abra Mods.\n3. Toque em Verificar.\n4. Toque em Adicionar ao lado do mod que deseja importar.\n\nA verificação analisa apenas a pasta principal Downloads. Mova o arquivo para lá se o navegador o tiver salvo em outro local.</string>
+    <string name="external_mods_ad_dialog_message">%1$s usa uma página de download com anúncios escolhida pelo desenvolvedor. O LeviLauncher não controla essa página nem seus anúncios.\n\n1. Toque em Abrir link e baixe o arquivo .levipack ou .so.\n2. Volte ao LeviLauncher e abra Mods.\n3. Toque em Verificar.\n4. Toque em Adicionar ao lado do mod que deseja importar.\n\nA verificação analisa apenas a pasta principal Downloads. Baixe apenas o arquivo do mod; não instale aplicativos não relacionados nem permita notificações.</string>
+    <string name="external_mods_by_author">por %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Atualizar</string>
+    <string name="external_mods_installed_button">Instalado</string>
+    <string name="external_mods_incompatible">Incompatível</string>
 
+    <!-- Mod Detail -->
     <string name="mod_detail_title">Detalhes do Mod</string>
     <string name="delete_mod">Excluir Mod</string>
     <string name="error_loading_mod">Erro ao carregar detalhes</string>
@@ -399,10 +512,63 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="mod_disabled">Mod desativado</string>
     <string name="mod_filename_format">Arquivo: %s</string>
     <string name="mod_enable_status">Status de Ativação</string>
+    <string name="mod_icon_content_description">Ícone do mod</string>
+    <string name="mod_author_byline">por %s</string>
+    <string name="mod_version_chip">Versão %s</string>
+    <string name="mod_metadata_title">Informações</string>
+    <string name="mod_actions_title">Ações</string>
+    <string name="mod_author_label">Autor</string>
+    <string name="mod_version_label">Versão</string>
+    <string name="mod_minecraft_versions_label">Versões do Minecraft</string>
+    <string name="mod_entry_label">Arquivo de entrada</string>
+    <string name="mod_id_label">ID do mod</string>
+    <string name="mod_config_files_label">Arquivos de configuração</string>
+    <string name="mod_unknown_author">Autor desconhecido</string>
+    <string name="mod_unknown_version">Versão desconhecida</string>
+    <string name="mod_all_versions">Todas as versões compatíveis</string>
+    <string name="mod_no_config_files">Nenhuma configuração editável</string>
+    <string name="mod_config_badge">CONFIG</string>
+    <string name="mod_config_badge_with_count">CONFIG · %d</string>
+    <string name="mod_config_title_format">Configuração de %s</string>
+    <string name="mod_config_not_found">Nenhuma configuração editável encontrada</string>
+    <string name="mod_config_load_failed">Falha ao carregar configuração: %s</string>
+    <string name="mod_config_save_failed">Falha ao salvar configuração</string>
+    <string name="mod_config_saved">Configuração salva</string>
+    <string name="mod_config_restart_hint">O arquivo de configuração foi salvo e um arquivo .backup foi mantido.</string>
+    <string name="mod_config_validation_failed">Falha na validação da configuração</string>
+    <string name="mod_config_invalid_json">JSON inválido</string>
+    <string name="mod_config_expand">Expandir</string>
+    <string name="mod_config_collapse">Recolher</string>
+    <string name="mod_config_raw_json">Editar JSON original</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">Item %1$s</string>
+    <string name="mod_config_object_desc">Grupo de configurações relacionadas</string>
+    <string name="mod_config_array_desc">Lista de valores</string>
+    <string name="mod_config_range_prefix">Intervalo</string>
+    <string name="mod_config_error_number">%1$s deve ser um número</string>
+    <string name="mod_config_error_minimum">%1$s deve ser pelo menos %2$s</string>
+    <string name="mod_config_error_maximum">%1$s deve ser no máximo %2$s</string>
+    <string name="mod_config_error_boolean">%1$s deve estar ligado ou desligado</string>
+    <string name="mod_config_error_string">%1$s deve ser texto</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d configuração editável</item>
+        <item quantity="other">%d configurações editáveis</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d opção</item>
+        <item quantity="other">%d opções</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d item</item>
+        <item quantity="other">%d itens</item>
+    </plurals>
 
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">Selecione a Versão do Jogo</string>
     <string name="back">Voltar</string>
 
+    <!-- Splash -->
     <string name="splash_logo_desc">Logo da folha</string>
     <string name="minecraft_loading_title">Iniciando Minecraft</string>
     <string name="minecraft_loading_subtitle">Preparando bibliotecas nativas e mods ativados</string>
@@ -416,6 +582,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="launcher_restart_subtitle">Aguarde um momento, você voltará à tela principal</string>
     <string name="launcher_restart_status">Quase lá…</string>
 
+    <!-- Accounts & Microsoft Login -->
     <string name="accounts_title">Contas</string>
     <string name="microsoft_accounts">Contas da Microsoft</string>
     <string name="manage_accounts">Gerenciar contas</string>
@@ -426,13 +593,45 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="accounts_active_privilege">Conectado</string>
 
     <string name="ms_login_title">Login da Microsoft</string>
+    <string name="ms_login_header_subtitle">Entre no Minecraft com segurança</string>
     <string name="ms_login_starting">Iniciando login da Microsoft…</string>
     <string name="ms_login_exchanging">Trocando token…</string>
     <string name="ms_login_auth_xbox_device">Autenticando dispositivo Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Buscando identidade do Minecraft…</string>
+    <string name="ms_login_retrying">Conexão interrompida. Tentando novamente com segurança…</string>
     <string name="ms_login_success">Logado como %1$s</string>
     <string name="ms_login_failed">Falha no login da Microsoft</string>
     <string name="ms_login_failed_detail">Falha no login: %1$s</string>
+    <string name="ms_choose_login_method">Entrar no Minecraft</string>
+    <string name="ms_choose_login_method_desc">Escolha o fluxo de código do dispositivo pelo navegador ou continue com a página da Microsoft incorporada.</string>
+    <string name="ms_device_code_login">Continuar com o navegador</string>
+    <string name="ms_device_code_option_title">Código do dispositivo (recomendado)</string>
+    <string name="ms_device_code_login_desc">Abra uma sessão privada do navegador com o código do dispositivo já preenchido.</string>
+    <string name="ms_webview_login">Abrir login incorporado</string>
+    <string name="ms_webview_option_title">WebView incorporada</string>
+    <string name="ms_webview_login_desc">Entre sem sair do LeviLauncher. Use esta opção quando o fluxo pelo navegador não estiver disponível.</string>
+    <string name="ms_device_code_title">Entrar com código do dispositivo</string>
+    <string name="ms_device_code_instructions">Abra a página de login por dispositivo da Microsoft, digite este código e aprove o acesso. O LeviLauncher concluirá automaticamente.</string>
+    <string name="ms_device_code_label">Código do dispositivo Microsoft</string>
+    <string name="ms_device_code_requesting">Solicitando um código seguro…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Aguardando você concluir no navegador…</string>
+    <string name="ms_device_code_checking">Verificando o resultado do login da Microsoft…</string>
+    <string name="ms_device_code_reconnecting">A conexão mudou. Tentando novamente automaticamente…</string>
+    <string name="ms_device_code_authorized">A Microsoft aprovou o login. Finalizando…</string>
+    <string name="ms_device_code_browser_opened">Conclua o novo login da Microsoft no navegador e depois volte para cá.</string>
+    <string name="ms_device_code_expires">O código expira em %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Copiar código</string>
+    <string name="ms_device_code_copied">Código copiado</string>
+    <string name="ms_device_code_open_browser">Abrir login da Microsoft</string>
+    <string name="ms_device_code_step_title">Conclua o login no navegador</string>
+    <string name="ms_device_code_browser_note">O LeviLauncher abre seu navegador padrão em uma sessão privada, preenche o código automaticamente e solicita um novo login da Microsoft.</string>
+    <string name="ms_choose_other_method">Outro método</string>
+    <string name="ms_no_browser">Nenhum navegador está disponível neste dispositivo.</string>
+    <string name="ms_default_browser_no_private_mode">Seu navegador padrão não oferece suporte a login privado. Atualize-o ou use o login por WebView.</string>
+    <string name="ms_login_ssl_failed">Não foi possível verificar a página segura de login da Microsoft.</string>
+    <string name="ms_login_state_failed">Não foi possível verificar a resposta de login da Microsoft. Inicie o login novamente.</string>
+    <string name="ms_login_missing_code">A Microsoft não retornou um código de login. Inicie o login novamente ou use o login por Código do dispositivo.</string>
 
     <string name="ms_set_active">Definir Ativa</string>
     <string name="ms_delete">Excluir</string>
@@ -445,9 +644,14 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="go_to_accounts">Contas</string>
     <string name="disable_launcher_login_and_continue">Fechar</string>
 
+    <string name="ms_feature_disabled_title">Recurso desativado</string>
+    <string name="ms_feature_disabled_desc">Ative “Entrar no Minecraft com LeviLauncher” nas Configurações para gerenciar contas da Microsoft.</string>
+    <string name="ms_activated">Ativado</string>
+
+    <!-- Popup labels -->
     <string name="label_current_account">Conta Atual</string>
     <string name="label_other_accounts">Outras Contas</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">O aplicativo falhou</string>
     <string name="crash_upload">Enviar relatório de falha</string>
     <string name="crash_details_title">Detalhes da falha</string>
@@ -466,8 +670,15 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="dialog_message_exit_app">Tem certeza de que deseja sair?</string>
     <string name="dialog_positive_exit">Sair</string>
     <string name="show_logcat_overlay">Sobreposição de Logcat</string>
+    <string name="foreground_service">Serviço em primeiro plano</string>
+    <string name="foreground_service_desc">Mantenha o Minecraft em execução ao alternar entre aplicativos, impedindo que o Bedrock suspenda a sessão ativa e mantendo o processo, a CPU e o Wi-Fi ativos.</string>
+    <string name="foreground_service_warning">Observação: pode fazer o telefone esquentar mais rápido e aumentar o consumo de bateria.</string>
+    <string name="foreground_service_channel">Proteção do Minecraft em segundo plano</string>
+    <string name="foreground_service_notification_title">Minecraft está sendo mantido ativo</string>
+    <string name="foreground_service_notification_text">O modo em segundo plano do Minecraft está ativo. A CPU e o acesso à rede estão sendo mantidos disponíveis para a sessão atual.</string>
     <string name="logcat_live">Logcat: <b>ao vivo</b></string>
     <string name="logcat_paused">Logcat: pausado</string>
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">Filtro de palavra-chave</string>
     <string name="logcat_blacklist_hint">Lista negra (separado por vírgulas)</string>
     <string name="logcat_filter_clear">Limpar filtros</string>
@@ -479,6 +690,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="logcat_corner_bottom_left">Redimensionar: inf-esq</string>
     <string name="logcat_corner_bottom_right">Redimensionar: inf-dir</string>
 
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mods">Mods Integrados</string>
     <string name="inbuilt_mods_title">Mods Integrados</string>
     <string name="inbuilt_mods_subtitle">Mods que rodam sem bibliotecas nativas</string>
@@ -487,7 +699,8 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="inbuilt_mod_removed">%s removido dos mods</string>
     <string name="add">Adicionar</string>
     <string name="remove">Remover</string>
-
+    
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">Gota Rápida</string>
     <string name="inbuilt_mod_quick_drop_desc">Jogue itens rapidamente</string>
     <string name="inbuilt_mod_camera">Perspectiva Rápida</string>
@@ -515,16 +728,25 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="virtual_cursor_enabled">Cursor ativado</string>
     <string name="virtual_cursor_disabled">Cursor desativado</string>
     <string name="cursor_sensitivity_label">Sensibilidade do Cursor:</string>
+    <string name="inbuilt_mod_gyro">Giroscópio</string>
+    <string name="inbuilt_mod_gyro_desc">Use o giroscópio do dispositivo para controlar a rotação da câmera</string>
+    <string name="inbuilt_mod_pojav_controls">Controles Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Substitua os controles de toque do Minecraft por controles no estilo Pojav totalmente personalizáveis</string>
+    <string name="inbuilt_mod_more_buttons">Mais botões</string>
+    <string name="inbuilt_mod_more_buttons_desc">Crie botões personalizados na tela com mapeamento de uma única tecla e ícones SVG</string>
     <string name="inbuilt_badge">INTEGRADO</string>
     <string name="autosprint_keybind_label">Tecla de Auto Sprint:</string>
     <string name="autosprint_keybind_press">Pressione qualquer tecla…</string>
     <string name="configure">Configurar</string>
     <string name="overlay_button_size">Tamanho do Botão Sobreposto</string>
     <string name="overlay_button_opacity">Opacidade do Botão Sobreposto</string>
+    <string name="overlay_button_size_value">Tamanho: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Opacidade: %1$d%%</string>
     <string name="overlay_button_lock">Travar Posição</string>
     <string name="overlay_button_lock_desc">Evita cliques ou arrastes acidentais</string>
     <string name="settings">Configurações</string>
 
+    <!-- Extract Structures -->
     <string name="extract_structures">Extrair Estruturas</string>
     <string name="no_structures_found">Nenhuma estrutura encontrada neste mundo</string>
     <string name="no_structures_found_title">Nenhuma Estrutura Encontrada</string>
@@ -538,15 +760,36 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="structures_found_title">Estruturas Encontradas</string>
     <string name="structures_found_count">%d estruturas encontradas neste mundo</string>
 
+    <!-- Mod Menu -->
     <string name="mod_menu">Menu de Mods</string>
     <string name="mod_menu_modules">Módulos</string>
+    <string name="mod_menu_favorites">Favoritos</string>
+    <string name="mod_menu_favorite">Adicionar aos favoritos</string>
+    <string name="mod_menu_unfavorite">Remover dos favoritos</string>
+    <string name="mod_menu_hud_editor">Editor de HUD</string>
+    <string name="mod_menu_filter_enabled">Ativados</string>
+    <string name="mod_menu_filter_inbuilt">Integrados</string>
+    <string name="mod_menu_filter_external">Externos</string>
     <string name="mod_menu_search_hint">Procurar mods…</string>
     <string name="mod_menu_no_mods">Nenhum mod adicionado</string>
+    <string name="mod_menu_no_favorites">Ainda não há mods favoritos</string>
+    <string name="mod_menu_no_matches">Nenhum mod correspondente</string>
+    <string name="mod_menu_group_inbuilt">Recursos integrados</string>
+    <string name="mod_menu_group_external_ungrouped">Mods externos sem grupo</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Configurações gerais</string>
+    <string name="mod_menu_appearance">Aparência</string>
+    <string name="mod_menu_pause_menu_only">Apenas no menu de pausa</string>
+    <string name="mod_menu_pause_menu_only_desc">Mostrar o menu de mods apenas na tela de pausa</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Configurações em breve</string>
     <string name="mod_menu_notifications">Notificações</string>
     <string name="mod_menu_notifications_desc">Mostrar notificação ao ativar mods</string>
     <string name="mod_menu_opacity">Opacidade do Menu de Mods</string>
     <string name="mod_menu_button_opacity">Opacidade do Botão do Menu</string>
+    <string name="mod_menu_compact">Menu de mods compacto</string>
+    <string name="mod_menu_compact_desc">Use um menu menor com uma lista de módulos mais densa e filtros compactos</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Menu de Mods ativado</string>
     <string name="mod_menu_disabled">Menu de Mods desativado</string>
@@ -555,7 +798,37 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="mod_status_enabled">Ativado</string>
     <string name="mod_status_disabled">Desativado</string>
     <string name="mod_notification_enabled">%s ativado</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Tamanho do botão de sobreposição (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacidade da sobreposição (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Mostrar em todos os lugares</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilidade do cursor (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Nível de zoom (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Atalho de corrida automática</string>
+    <string name="mod_config_zoom_keybind">Atalho de zoom</string>
+    <string name="mod_config_zoom_transition">Duração da transição (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicador de sensibilidade (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Velocidade horizontal (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Velocidade vertical (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Filtro de pequenos movimentos (0 = Desativado)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilidade horizontal (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilidade vertical (%)</string>
+    <string name="mod_config_gyro_invert_x">Inverter eixo horizontal</string>
+    <string name="mod_config_gyro_invert_y">Inverter eixo vertical</string>
+    <string name="mod_config_gyro_deadzone">Zona morta</string>
+    <string name="mod_config_press_any_key">Pressione qualquer tecla para atribuir...</string>
+    <string name="mod_config_key_unknown">DESCONHECIDO</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Arraste para mover o painel</string>
+    <string name="hud_editor_drag_description">Editor de HUD. Arraste esta área para mover o painel.</string>
 
+    <!-- Options Editor -->
     <string name="edit_options">Editar Opções</string>
     <string name="options_file_not_found">Arquivo de opções não encontrado</string>
     <string name="no_options_found">Nenhuma opção encontrada</string>
@@ -564,6 +837,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="error_loading_options">Erro ao carregar opções</string>
     <string name="options_saved">Opções salvas com sucesso</string>
 
+    <!-- Quick Launch -->
     <string name="quick_launch_title">Início Rápido</string>
     <string name="quick_launch_subtitle">Inicie o Minecraft com ações de protocolo URI</string>
     <string name="quick_launch_how_to_play">Como Jogar</string>
@@ -591,6 +865,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="quick_launch_custom_uri">URI Personalizada</string>
     <string name="quick_launch_custom_uri_desc">Insira um minecraft:// URI</string>
 
+    <!-- Quick Launch Dialogs -->
     <string name="server_ip_hint">Endereço IP do Servidor</string>
     <string name="server_port_hint">Porta (padrão: 19132)</string>
     <string name="server_name_hint">Nome do Servidor</string>
@@ -602,6 +877,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="custom_uri_hint">Insira URI completo. Ex: \nminecraft://openStore\nminecraft://?showStoreOffer=UUID</string>
     <string name="select_tab">Selecionar Aba:</string>
 
+    <!-- Quick Launch Validation -->
     <string name="server_ip_required">O IP do servidor é obrigatório</string>
     <string name="server_details_required">Nome e IP do servidor são obrigatórios</string>
     <string name="invalid_port">Número de porta inválido</string>
@@ -610,14 +886,17 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="command_required">Comando obrigatório</string>
     <string name="invalid_minecraft_uri">URI inválida</string>
 
+    <!-- Quick Launch Actions -->
     <string name="connect">Conectar</string>
     <string name="join">Entrar</string>
     <string name="load">Carregar</string>
     <string name="execute">Executar</string>
 
+    <!-- Quick Actions Menu -->
     <string name="quick_launch">Início Rápido</string>
     <string name="quick_launch_menu_subtitle">Inicie com ações URI</string>
 
+    <!-- CurseForge -->
     <string name="curseforge_title">CurseForge</string>
     <string name="curseforge_subtitle">Pesquise e baixe conteúdos</string>
     <string name="curseforge_search_hint">Procurar conteúdos…</string>
@@ -627,6 +906,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="curseforge_download_failed">Falha no download</string>
     <string name="curseforge_available_files">Arquivos Disponíveis</string>
 
+    <!-- Navigation Bar -->
     <string name="nav_launch">Iniciar</string>
     <string name="nav_import">Importar</string>
     <string name="nav_instances">Instâncias</string>
@@ -673,7 +953,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
         <item>O CurseForge permite que você baixe conteúdo da comunidade diretamente.</item>
         <item>Carregue módulos SO para estender ou melhorar os recursos e o desempenho do Minecraft.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Cor do Tema</string>
     <string name="theme_color_desc">A cor de destaque principal do app</string>
     <string name="preset_colors">CORES PRÉ-DEFINIDAS</string>
@@ -691,163 +971,8 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
 
     <string name="unsupported_version_title">Versão não suportada</string>
     <string name="unsupported_version_msg">Este lançador não suporta versões do Minecraft anteriores a 1.21.80.</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">por %s</string>
-    <string name="mod_version_chip">Versão %s</string>
-    <string name="mod_config_title_format">Configuração de %s</string>
-    <string name="mod_config_not_found">Nenhuma configuração editável encontrada</string>
-    <string name="mod_config_load_failed">Falha ao carregar configuração: %s</string>
-    <string name="mod_config_save_failed">Falha ao salvar configuração</string>
-    <string name="mod_config_saved">Configuração salva</string>
-    <string name="mod_config_restart_hint">O arquivo de configuração foi salvo e um arquivo .backup foi mantido.</string>
-    <string name="mod_config_validation_failed">Falha na validação da configuração</string>
-    <string name="mod_config_invalid_json">JSON inválido</string>
-    <string name="mod_config_expand">Expandir</string>
-    <string name="mod_config_collapse">Recolher</string>
-    <string name="mod_config_raw_json">Editar JSON original</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">Item %1$s</string>
-    <string name="mod_config_object_desc">Grupo de configurações relacionadas</string>
-    <string name="mod_config_array_desc">Lista de valores</string>
-    <string name="mod_config_range_prefix">Intervalo</string>
-    <string name="mod_config_error_number">%1$s deve ser um número</string>
-    <string name="mod_config_error_minimum">%1$s deve ser pelo menos %2$s</string>
-    <string name="mod_config_error_maximum">%1$s deve ser no máximo %2$s</string>
-    <string name="mod_config_error_boolean">%1$s deve estar ligado ou desligado</string>
-    <string name="mod_config_error_string">%1$s deve ser texto</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d configuração editável</item>
-        <item quantity="other">%d configurações editáveis</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d opção</item>
-        <item quantity="other">%d opções</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d item</item>
-        <item quantity="other">%d itens</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Favoritos</string>
-    <string name="mod_menu_favorite">Adicionar aos favoritos</string>
-    <string name="mod_menu_unfavorite">Remover dos favoritos</string>
-    <string name="mod_menu_hud_editor">Editor de HUD</string>
-    <string name="mod_menu_filter_enabled">Ativados</string>
-    <string name="mod_menu_filter_inbuilt">Integrados</string>
-    <string name="mod_menu_filter_external">Externos</string>
-    <string name="mod_menu_no_favorites">Ainda não há mods favoritos</string>
-    <string name="mod_menu_no_matches">Nenhum mod correspondente</string>
-    <string name="mod_menu_group_inbuilt">Recursos integrados</string>
-    <string name="mod_menu_group_external_ungrouped">Mods externos sem grupo</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Configurações gerais</string>
-    <string name="mod_menu_appearance">Aparência</string>
-    <string name="mod_menu_pause_menu_only">Apenas no menu de pausa</string>
-    <string name="mod_menu_pause_menu_only_desc">Mostrar o menu de mods apenas na tela de pausa</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Tamanho do botão de sobreposição (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Opacidade da sobreposição (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Sensibilidade do cursor (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Nível de zoom (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Atalho de corrida automática</string>
-    <string name="mod_config_zoom_keybind">Atalho de zoom</string>
-    <string name="mod_config_press_any_key">Pressione qualquer tecla para atribuir...</string>
-    <string name="mod_config_key_unknown">DESCONHECIDO</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Tamanho: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Opacidade: %1$d%%</string>
-    <string name="reset">Redefinir</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Excluir conta</string>
-    <string name="delete_account_confirm">Tem certeza de que deseja excluir esta conta?</string>
-    <string name="instance_backup_title">Backup da instância</string>
-    <string name="instance_backup_desc">Crie um backup completo desta instância em Download/LeviLauncher/Backups.</string>
-    <string name="instance_backup_button">Fazer backup da instância</string>
-    <string name="instance_backup_confirm_message">Criar um backup completo desta instância agora? Feche o Minecraft primeiro se ele estiver em execução para evitar alterações nos arquivos durante o backup.</string>
-    <string name="instance_backup_in_progress">Fazendo backup da instância…</string>
-    <string name="instance_backup_success_title">Backup criado</string>
-    <string name="instance_backup_success_message">Backup salvo em:\n%1$s</string>
-    <string name="instance_backup_failed_title">Falha no backup</string>
-    <string name="instance_backup_failed_message">Não foi possível criar o backup:\n%1$s</string>
-    <string name="instance_import_backup_button">Importar backup</string>
-    <string name="instance_restore_title">Restaurar backup</string>
-    <string name="instance_restore_in_progress">Restaurando backup da instância…</string>
-    <string name="instance_restore_success_title">Restauração concluída</string>
-    <string name="instance_restore_success_message">Restaurado: %1$s</string>
-    <string name="instance_restore_failed_title">Falha na restauração</string>
-    <string name="instance_restore_failed_message">Não foi possível restaurar o backup:\n%1$s</string>
-    <string name="mod_icon_content_description">Ícone do mod</string>
-    <string name="mod_metadata_title">Informações</string>
-    <string name="mod_actions_title">Ações</string>
-    <string name="mod_author_label">Autor</string>
-    <string name="mod_version_label">Versão</string>
-    <string name="mod_minecraft_versions_label">Versões do Minecraft</string>
-    <string name="mod_entry_label">Arquivo de entrada</string>
-    <string name="mod_id_label">ID do mod</string>
-    <string name="mod_config_files_label">Arquivos de configuração</string>
-    <string name="mod_unknown_author">Autor desconhecido</string>
-    <string name="mod_unknown_version">Versão desconhecida</string>
-    <string name="mod_all_versions">Todas as versões compatíveis</string>
-    <string name="mod_no_config_files">Nenhuma configuração editável</string>
-    <string name="mod_config_badge">CONFIG</string>
-    <string name="mod_config_badge_with_count">CONFIG · %d</string>
-    <string name="ms_login_header_subtitle">Entre no Minecraft com segurança</string>
-    <string name="ms_login_retrying">Conexão interrompida. Tentando novamente com segurança…</string>
-    <string name="ms_choose_login_method">Entrar no Minecraft</string>
-    <string name="ms_choose_login_method_desc">Escolha o fluxo de código do dispositivo pelo navegador ou continue com a página da Microsoft incorporada.</string>
-    <string name="ms_device_code_login">Continuar com o navegador</string>
-    <string name="ms_device_code_option_title">Código do dispositivo (recomendado)</string>
-    <string name="ms_device_code_login_desc">Abra uma sessão privada do navegador com o código do dispositivo já preenchido.</string>
-    <string name="ms_webview_login">Abrir login incorporado</string>
-    <string name="ms_webview_option_title">WebView incorporada</string>
-    <string name="ms_webview_login_desc">Entre sem sair do LeviLauncher. Use esta opção quando o fluxo pelo navegador não estiver disponível.</string>
-    <string name="ms_device_code_title">Entrar com código do dispositivo</string>
-    <string name="ms_device_code_instructions">Abra a página de login por dispositivo da Microsoft, digite este código e aprove o acesso. O LeviLauncher concluirá automaticamente.</string>
-    <string name="ms_device_code_label">Código do dispositivo Microsoft</string>
-    <string name="ms_device_code_requesting">Solicitando um código seguro…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Aguardando você concluir no navegador…</string>
-    <string name="ms_device_code_checking">Verificando o resultado do login da Microsoft…</string>
-    <string name="ms_device_code_reconnecting">A conexão mudou. Tentando novamente automaticamente…</string>
-    <string name="ms_device_code_authorized">A Microsoft aprovou o login. Finalizando…</string>
-    <string name="ms_device_code_browser_opened">Conclua o novo login da Microsoft no navegador e depois volte para cá.</string>
-    <string name="ms_device_code_expires">O código expira em %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Copiar código</string>
-    <string name="ms_device_code_copied">Código copiado</string>
-    <string name="ms_device_code_open_browser">Abrir login da Microsoft</string>
-    <string name="ms_device_code_step_title">Conclua o login no navegador</string>
-    <string name="ms_device_code_browser_note">O LeviLauncher abre seu navegador padrão em uma sessão privada, preenche o código automaticamente e solicita um novo login da Microsoft.</string>
-    <string name="ms_choose_other_method">Outro método</string>
-    <string name="ms_no_browser">Nenhum navegador está disponível neste dispositivo.</string>
-    <string name="ms_default_browser_no_private_mode">Seu navegador padrão não oferece suporte a login privado. Atualize-o ou use o login por WebView.</string>
-    <string name="ms_login_ssl_failed">Não foi possível verificar a página segura de login da Microsoft.</string>
-    <string name="ms_login_state_failed">Não foi possível verificar a resposta de login da Microsoft. Inicie o login novamente.</string>
-    <string name="ms_login_missing_code">A Microsoft não retornou um código de login. Inicie o login novamente ou use o login por Código do dispositivo.</string>
-    <string name="ms_feature_disabled_title">Recurso desativado</string>
-    <string name="ms_feature_disabled_desc">Ative “Entrar no Minecraft com LeviLauncher” nas Configurações para gerenciar contas da Microsoft.</string>
-    <string name="ms_activated">Ativado</string>
-    <string name="inbuilt_mod_gyro">Giroscópio</string>
-    <string name="inbuilt_mod_gyro_desc">Use o giroscópio do dispositivo para controlar a rotação da câmera</string>
-    <string name="inbuilt_mod_pojav_controls">Controles Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Substitua os controles de toque do Minecraft por controles no estilo Pojav totalmente personalizáveis</string>
-    <string name="inbuilt_mod_more_buttons">Mais botões</string>
-    <string name="inbuilt_mod_more_buttons_desc">Crie botões personalizados na tela com mapeamento de uma única tecla e ícones SVG</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Mostrar em todos os lugares</string>
-    <string name="mod_config_zoom_transition">Duração da transição (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Sensibilidade horizontal (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Sensibilidade vertical (%)</string>
-    <string name="mod_config_gyro_invert_x">Inverter eixo horizontal</string>
-    <string name="mod_config_gyro_invert_y">Inverter eixo vertical</string>
-    <string name="mod_config_gyro_deadzone">Zona morta</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Fechar</string>
     <string name="previous">Anterior</string>
     <string name="next">Próximo</string>
@@ -897,6 +1022,8 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="custom_color_hint">#RRGGBB ou R,G,B</string>
     <string name="screenshot_name_placeholder">Nome da captura de tela</string>
     <string name="screenshot_date_placeholder">Data: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Crie botões na tela no estilo Minecraft, cada um mapeado para exatamente uma tecla do teclado. Os botões nunca executam macros, sequências de teclas, repetições automáticas ou autoclick.</string>
     <string name="more_buttons_add_button">Adicionar botão</string>
     <string name="more_buttons_limit_reached">O limite máximo de %1$d botões personalizados foi atingido.</string>
@@ -954,99 +1081,17 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="more_buttons_no_svg_selected">Nenhum SVG selecionado</string>
     <string name="more_buttons_default_name">Botão</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Slot da barra rápida</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Adiciona botões separados de 1 a 9 para selecionar slots da barra rápida</string>
     <string name="hotbar_slot_content_description">Slot da barra rápida %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Atalho da tela inicial</string>
-    <string name="instance_shortcut_desc">As alterações de nome e ícone são salvas automaticamente. Toque em Adicionar atalho para criar ou atualizar o atalho da tela inicial.</string>
-    <string name="instance_shortcut_name">Nome do atalho</string>
-    <string name="instance_shortcut_icon">Ícone do atalho</string>
-    <string name="instance_shortcut_choose_icon">Escolher ícone</string>
-    <string name="instance_shortcut_default_icon">Usar padrão</string>
-    <string name="instance_shortcut_add_button">Adicionar atalho</string>
-    <string name="instance_settings_auto_save_failed">Não foi possível salvar esta configuração da instância.</string>
-    <string name="instance_shortcut_not_supported">Seu launcher da tela inicial não oferece suporte a atalhos fixados.</string>
-    <string name="instance_shortcut_missing">Esta instância do Minecraft não está mais disponível.</string>
-    <string name="custom_flat_world_subtitle">Crie um mundo com seu próprio bioma e camadas de blocos</string>
-    <string name="world_settings">Configurações do mundo</string>
-    <string name="world_settings_hint">Escolha as configurações básicas do novo mundo</string>
-    <string name="layers_title">Camadas</string>
-    <string name="add_layer_compact">Adicionar camada</string>
-    <string name="no_layers_title">Ainda não há camadas</string>
-    <string name="no_layers_hint">Adicione pelo menos uma camada de blocos para criar o mundo</string>
-    <string name="reorder_layer">Reordenar camada</string>
-    <string name="delete_layer">Excluir camada</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Verificar</string>
-    <string name="scan_downloads_scanning">Verificando…</string>
-    <string name="scan_downloads_none_found">Nenhum mod .levipack ou .so encontrado em Downloads</string>
-    <string name="scan_downloads_failed">Não foi possível verificar Downloads</string>
-    <string name="scan_downloads_permission_denied">É necessário acesso ao armazenamento para verificar Downloads</string>
-    <string name="scan_downloads_results_title">Mods em Downloads</string>
-    <string name="scan_downloads_results_subtitle">Escolha um mod para adicionar. A verificação analisa apenas a pasta principal Downloads.</string>
-    <string name="scan_downloads_add">Adicionar</string>
-    <string name="scan_downloads_adding">Adicionando…</string>
-    <string name="scan_downloads_added">Adicionado</string>
-    <string name="scan_downloads_added_message">%1$s adicionado</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Biblioteca nativa</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Mods externos</string>
-    <string name="external_mods_subtitle">Mods da comunidade para Minecraft %1$s</string>
-    <string name="external_mods_no_version">Selecione uma versão do Minecraft antes de instalar mods</string>
-    <string name="external_mods_search_hint">Pesquisar mods, autores ou versões…</string>
-    <string name="external_mods_compatible_only">Somente compatíveis</string>
-    <string name="external_mods_all_versions">Todas as versões do Minecraft</string>
-    <string name="external_mods_sort_newest">Mais recentes</string>
-    <string name="external_mods_sort_name">Nome A–Z</string>
-    <string name="external_mods_empty">Nenhum mod corresponde a estes filtros</string>
-    <string name="external_mods_load_failed">Não foi possível atualizar o catálogo. Exibindo a cópia salva.</string>
-    <string name="external_mods_refresh">Atualizar catálogo</string>
-    <string name="external_mods_refreshed">Catálogo atualizado</string>
-    <string name="external_mods_join_discord">Entrar no Discord da comunidade</string>
-    <string name="external_mods_discord_open_failed">Nenhum aplicativo pode abrir o convite do Discord</string>
-    <string name="external_mods_download">Baixando %1$s</string>
-    <string name="external_mods_importing">Importando mod…</string>
-    <string name="external_mods_installed">%1$s instalado</string>
-    <string name="external_mods_install_failed">Não foi possível instalar %1$s: %2$s</string>
-    <string name="external_mods_open_failed">Nenhum navegador pode abrir este download</string>
-    <string name="external_mods_direct_download">Download direto</string>
-    <string name="external_mods_ad_download">Download com anúncios</string>
-    <string name="external_mods_external_link">Link externo</string>
-    <string name="external_mods_open_link">Abrir link</string>
-    <string name="external_mods_external_dialog_title">Download externo</string>
-    <string name="external_mods_ad_dialog_title">Download com anúncios</string>
-    <string name="external_mods_external_dialog_message">%1$s usa uma página de download fora do LeviLauncher.\n\n1. Toque em Abrir link e baixe o arquivo .levipack ou .so.\n2. Volte ao LeviLauncher e abra Mods.\n3. Toque em Verificar.\n4. Toque em Adicionar ao lado do mod que deseja importar.\n\nA verificação analisa apenas a pasta principal Downloads. Mova o arquivo para lá se o navegador o tiver salvo em outro local.</string>
-    <string name="external_mods_ad_dialog_message">%1$s usa uma página de download com anúncios escolhida pelo desenvolvedor. O LeviLauncher não controla essa página nem seus anúncios.\n\n1. Toque em Abrir link e baixe o arquivo .levipack ou .so.\n2. Volte ao LeviLauncher e abra Mods.\n3. Toque em Verificar.\n4. Toque em Adicionar ao lado do mod que deseja importar.\n\nA verificação analisa apenas a pasta principal Downloads. Baixe apenas o arquivo do mod; não instale aplicativos não relacionados nem permita notificações.</string>
-    <string name="external_mods_by_author">por %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Atualizar</string>
-    <string name="external_mods_installed_button">Instalado</string>
-    <string name="external_mods_incompatible">Incompatível</string>
-    <string name="foreground_service">Serviço em primeiro plano</string>
-    <string name="foreground_service_desc">Mantenha o Minecraft em execução ao alternar entre aplicativos, impedindo que o Bedrock suspenda a sessão ativa e mantendo o processo, a CPU e o Wi-Fi ativos.</string>
-    <string name="foreground_service_warning">Observação: pode fazer o telefone esquentar mais rápido e aumentar o consumo de bateria.</string>
-    <string name="foreground_service_channel">Proteção do Minecraft em segundo plano</string>
-    <string name="foreground_service_notification_title">Minecraft está sendo mantido ativo</string>
-    <string name="foreground_service_notification_text">O modo em segundo plano do Minecraft está ativo. A CPU e o acesso à rede estão sendo mantidos disponíveis para a sessão atual.</string>
-    <string name="mod_menu_compact">Menu de mods compacto</string>
-    <string name="mod_menu_compact_desc">Use um menu menor com uma lista de módulos mais densa e filtros compactos</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Multiplicador de sensibilidade (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Velocidade horizontal (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Velocidade vertical (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Filtro de pequenos movimentos (0 = Desativado)</string>
-    <string name="hud_editor_drag_hint">Arraste para mover o painel</string>
-    <string name="hud_editor_drag_description">Editor de HUD. Arraste esta área para mover o painel.</string>
     <string name="mod_config_hotbar_item_icons">Usar ícones de itens da barra rápida</string>
     <string name="mod_config_hotbar_item_counts">Mostrar quantidade de itens</string>
     <string name="mod_config_hotbar_slot_enabled">Mostrar slot %1$d da barra rápida</string>
     <string name="mod_config_hotbar_slot_size">Tamanho do slot %1$d da barra rápida (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Opacidade do slot %1$d da barra rápida</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Novidades</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Continuar</string>
@@ -1069,6 +1114,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="mod_config_category_button">Botão</string>
     <string name="mod_config_visible_slots">Slots visíveis</string>
     <string name="mod_config_hotbar_slot_section">Slot %1$d da barra rápida</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Selecionar</string>
     <string name="select_all">Selecionar tudo</string>
     <string name="selected">Selecionado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Para instalar ou atualizar este aplicativo, conceda permissão para instalar fontes desconhecidas.</string>
 
     <string name="check_update">Verificar atualizações</string>
-    <string name="version_prefix">Versão:</string>
+    <string name="version_prefix">Versão: </string>
     <string name="unknown_error">Erro desconhecido</string>
     <string name="preloader_sigs_title">Dados de execução</string>
     <string name="preloader_sigs_last_update">Última atualização: %1$s</string>
@@ -452,7 +452,7 @@ A migração deve ser concluída antes que o LeviLauncher continue.</string>
     <string name="genuine_badge_label">Licença não verificada</string>
     <string name="invalid_license_detected_toast">Minecraft não original detectado. Verifique a sua versão da Play Store.</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Total de Mods:</string>
     <string name="enabled_mods">Ativados:</string>
     <string name="add_mod">Adicionar Mod</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,12 +1,23 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
-    <!-- Общее -->
+    <!-- Common -->
     <string name="app_name">LeviLauncher</string>
     <string name="minecraft">Minecraft</string>
     <string name="launch">Запустить</string>
     <string name="beta_badge">Бета</string>
     <string name="debug_badge">Отладочная сборка</string>
+    <string name="cursor">Курсор</string>
+    <string name="bedrock_edition">Bedrock Edition</string>
+    <string name="current_instance">Текущий экземпляр</string>
 
-    <!-- Моды -->
+    <!-- Mods -->
     <string name="mods_title">Моды (%d)</string>
     <string name="mods_section_title">Моды</string>
     <string name="external_mods_label">Внешние моды</string>
@@ -17,18 +28,21 @@
     <string name="drag_to_reorder">Перетащите для изменения порядка</string>
     <string name="mod_reordered">Порядок модов обновлен</string>
 
-    <!-- О приложении -->
+    <!-- About -->
     <string name="about_title">☕ О приложении</string>
     <string name="copyright">©2024–2026 LeviMC. Все права защищены.</string>
     <string name="font_license">Это приложение использует шрифт Misans.</string>
     <string name="about_footer_github">GitHub: https://github.com/LiteLDev/LeviLaunchroid</string>
     <string name="quick_actions_title">Быстрые действия</string>
+    <string name="content_mgmt_section_title">Управление контентом</string>
+    <string name="misc_section_title">Разное</string>
+    <string name="view_all">Показать все →</string>
     <string name="content_management_subtitle">Управление мирами, ресурсами и аддонами</string>
     <string name="import_apk_subtitle">Установка Minecraft из файла APK или APKS</string>
     <string name="ms_add_account">Добавить аккаунт</string>
     <string name="ms_add_account_subtitle">Войти через Microsoft</string>
 
-    <!-- Диалоги -->
+    <!-- Dialogs -->
     <string name="content_detected_title">Обнаружен контент</string>
     <string name="content_detected_message">Хотите запустить игру сейчас?\n\nФайл: %s</string>
     <string name="launch_now">Запустить сейчас</string>
@@ -37,6 +51,11 @@
 
     <string name="import_confirmation_title">Импортировать моды</string>
     <string name="import_confirmation_message">Вы уверены в том что хотите импортировать выбранные %d файлы модов?</string>
+    <string name="import_so_plugin_title">Импорт SO-плагина</string>
+    <string name="plugin_name_label">Название плагина</string>
+    <string name="plugin_type_label">Тип</string>
+    <string name="plugin_version_label">Версия</string>
+    <string name="import_button">Импорт</string>
     <string name="overwrite_file_title">Файл Уже Существует</string>
     <string name="overwrite_file_message">Файл %s уже существует. Вы хотите перезаписать его?</string>
     <string name="overwrite">Перезаписать</string>
@@ -47,14 +66,14 @@
     <string name="installed_packages">Установленные пакеты</string>
     <string name="local_custom">Доступные версии</string>
 
-    <!-- Разрешения -->
+    <!-- Permissions -->
     <string name="storage_permission_title">Разрешение для миграции хранилища</string>
     <string name="storage_permission_message">Предоставьте доступ к хранилищу, чтобы LeviLauncher мог скопировать данные из старой папки games/org.levimc. Это разрешение нужно только для миграции.</string>
     <string name="grant_permission">Выдать</string>
     <string name="cancel">Отмена</string>
 
-    <!-- Обратная связь -->
-    <string name="files_processed">Успешно добавлены файлы мода %d </string>
+    <!-- Feedback -->
+    <string name="files_processed">Успешно добавлены файлы мода %d</string>
     <string name="user_cancelled">Импорт отменен пользователем</string>
 
 
@@ -84,12 +103,20 @@
 
     <string name="settings_title">Настройки</string>
     <string name="settings_desc">Настройки вашего лаунчера</string>
+    <string name="settings_subtitle">Настройка основных параметров лаунчера</string>
+    <string name="settings_tab_basic">Основные настройки</string>
+    <string name="settings_tab_personalize">Персонализация</string>
+    <string name="settings_tab_updates">Обновления</string>
+    <string name="settings_tab_about">О приложении</string>
+    <string name="settings_tab_migration">Миграция</string>
+    <string name="settings_theme_desc">Выберите тему приложения</string>
+
 
     <string name="unknown_sources_permission_title">Разрешение на установку</string>
     <string name="unknown_sources_permission_message">Чтобы установить или обновить это приложение, пожалуйста выдайте разрешение на установку неизвестных приложений. Нажмите "Выдать" чтобы открыть настройки системы, выдайте разрешение для этого приложения, и вернитесь чтобы продолжить.</string>
 
     <string name="check_update">Проверить обновления</string>
-    <string name="version_prefix">Версия: </string>
+    <string name="version_prefix">Версия:</string>
     <string name="unknown_error">Неизвестная ошибка</string>
     <string name="preloader_sigs_title">Данные среды выполнения</string>
     <string name="preloader_sigs_last_update">Последнее обновление: %1$s</string>
@@ -113,6 +140,8 @@
     <string name="dialog_message_disable_version_isolation">Вы пытаетесь запустить установленную версию с включенной изоляцией версии. Пожалуйста, отключите изоляцию версии, чтобы продолжить.</string>
     <string name="dialog_positive_disable">Отключить</string>
     <string name="dialog_positive_ok">ОК</string>
+    <string name="delete_account_title">Удалить учётную запись</string>
+    <string name="delete_account_confirm">Вы уверены, что хотите удалить эту учётную запись?</string>
 
 
     <string name="new_version_found">Найдена новая версия: %1$s</string>
@@ -141,6 +170,7 @@
     <string name="repair_preparing">Подготовка…</string>
     <string name="repair_processing">Извлечение библиотек…</string>
     <string name="repair_finalizing">Завершение восстановления…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Требуется миграция хранилища</string>
     <string name="storage_migration_message">LeviLauncher должен перенести данные из games/org.levimc в %1$s перед продолжением.
 
@@ -185,21 +215,21 @@
     <string name="shared_storage_layout_mode_legacy">Исходные внутренний/внешний каталоги</string>
     <string name="shared_storage_layout_status">Текущий режим: %1$s\nВнутренний: %2$s\nВнешний: %3$s</string>
     <string name="shared_storage_layout_changed">Выбор каталога хранилища обновлён. Перезапустите Minecraft и снова откройте управление контентом, чтобы изменение полностью применилось.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Тема</string>
     <string name="theme_follow_system">Как в системе</string>
     <string name="theme_light">Светлая тема</string>
     <string name="theme_dark">Тёмная тема</string>
 
     <string name="error_no_browser">Браузер не доступен</string>
-
+    <!-- License & Security -->
     <string name="eula_title">Лицензионное соглашение LeviLauncher</string>
     <string name="eula_message"><b>Добро пожаловать в LeviLauncher</b>\n\nПри использовании данной программы вы соглашаетесь с тем что:\n\n• Это <b>неофициальный</b> лаунчер Minecraft\n• Вам необходимо владеть <b>лицензионной</b> копией Minecraft\n• Любая форма пиратства и читов запрещена\n• Моды/наборы ресурсов используются на ваш риск\n• Не связано с Mojang/Microsoft\n\nДальнейшее использование означает согласие с лицензионным соглашением</string>
     <string name="eula_agree">Принять</string>
     <string name="eula_exit">Отклонить</string>
 
     <string name="allow_unknown_sources">Пожалуйста, разрешите установку из неизвестных источников и повторите попытку</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Удалить версию</string>
     <string name="dialog_message_delete_version">Вы уверены, что хотите удалить эту пользовательскую версию? Это действие не может быть отменено.</string>
     <string name="dialog_positive_delete">Удалить</string>
@@ -217,8 +247,68 @@
     <string name="dialog_message_delete_mod">Вы уверены, что хотите удалить этот мод?</string>
 
     <string name="version_isolation">Изоляция версий</string>
+    <string name="launch_vertically">Запуск вертикально</string>
+    <string name="launch_vertically_desc">Принудительно запускать игру в портретном режиме</string>
+    <!-- Instance Management -->
+    <string name="instance_settings_title">Настройки экземпляра</string>
+    <string name="instance_tab_general">Общие</string>
+    <string name="instance_tab_launch_options">Параметры запуска</string>
+    <string name="instance_tab_management">Управление</string>
+    <string name="instance_new_name">Новое имя</string>
+    <string name="instance_rename_hint">Переименовывается только папка. Версия и тип игры не изменяются.</string>
+    <string name="instance_custom_icon">Пользовательский значок (требуется квадрат)</string>
+    <string name="instance_clear_icon">Очистить</string>
+    <string name="instance_icon_hint">Будет сохранён как LargeLogo.png в папке версии. Нажмите на значок, чтобы изменить.</string>
+    <string name="instance_isolation_desc">Изолировать игровые данные для этого экземпляра. Другие экземпляры не будут затронуты.</string>
+    <string name="instance_shortcut_title">Ярлык на главном экране</string>
+    <string name="instance_shortcut_desc">Изменения имени и значка сохраняются автоматически. Нажмите «Добавить ярлык», чтобы создать или обновить ярлык на главном экране.</string>
+    <string name="instance_shortcut_name">Название ярлыка</string>
+    <string name="instance_shortcut_icon">Значок ярлыка</string>
+    <string name="instance_shortcut_choose_icon">Выбрать значок</string>
+    <string name="instance_shortcut_default_icon">Использовать стандартный</string>
+    <string name="instance_shortcut_add_button">Добавить ярлык</string>
+    <string name="instance_settings_auto_save_failed">Не удалось сохранить эту настройку экземпляра.</string>
+    <string name="instance_shortcut_not_supported">Ваш лаунчер главного экрана не поддерживает закреплённые ярлыки.</string>
+    <string name="instance_shortcut_missing">Этот экземпляр Minecraft больше недоступен.</string>
+    <string name="instance_danger_zone">Опасная зона</string>
+    <string name="instance_danger_zone_desc">Эти действия влияют на регистрацию экземпляра или локальные файлы. Проверьте всё перед продолжением.</string>
+    <string name="instance_delete_desc">Навсегда удаляет этот экземпляр с устройства, включая миры, настройки и установленный контент.</string>
+    <string name="instance_delete_warning">Это действие нельзя отменить.</string>
+    <string name="instance_delete_confirm_title">Удалить экземпляр</string>
+    <string name="instance_delete_confirm_msg">Вы уверены, что хотите удалить этот экземпляр? Все данные, включая миры, будут удалены навсегда.</string>
+    <string name="instance_backup_title">Резервная копия экземпляра</string>
+    <string name="instance_backup_desc">Создать полную резервную копию этого экземпляра в Download/LeviLauncher/Backups.</string>
+    <string name="instance_backup_button">Создать резервную копию экземпляра</string>
+    <string name="instance_backup_confirm_message">Создать полную резервную копию этого экземпляра сейчас? Если Minecraft запущен, сначала закройте его, чтобы файлы не менялись во время резервного копирования.</string>
+    <string name="instance_backup_in_progress">Создание резервной копии экземпляра…</string>
+    <string name="instance_backup_success_title">Резервная копия создана</string>
+    <string name="instance_backup_success_message">Резервная копия сохранена в:\n%1$s</string>
+    <string name="instance_backup_failed_title">Ошибка резервного копирования</string>
+    <string name="instance_backup_failed_message">Не удалось создать резервную копию:\n%1$s</string>
+    <string name="instance_import_backup_button">Импортировать резервную копию</string>
+    <string name="instance_batch_backup_button">Пакетная копия</string>
+    <string name="instance_batch_backup_title">Пакетное резервное копирование экземпляров</string>
+    <string name="instance_batch_backup_select_message">Выберите экземпляры для резервного копирования. Если Minecraft запущен, сначала выйдите из игры, чтобы избежать изменения данных во время копирования.</string>
+    <string name="instance_batch_backup_select_all">Выбрать все экземпляры</string>
+    <string name="instance_batch_backup_no_instances">Нет экземпляров, доступных для резервного копирования.</string>
+    <string name="instance_batch_backup_no_selection">Выберите хотя бы один экземпляр.</string>
+    <string name="instance_batch_backup_in_progress">Резервное копирование %1$s (%2$d/%3$d)…</string>
+    <string name="instance_batch_backup_success_title">Резервные копии созданы</string>
+    <string name="instance_batch_backup_success_message">Создано резервных копий: %1$d\n%2$s</string>
+    <string name="instance_batch_backup_partial_title">Резервное копирование частично завершено</string>
+    <string name="instance_batch_backup_partial_message">Создано резервных копий: %1$d, ошибок: %2$d.\n\nСохранено:\n%3$s\n\nОшибки:\n%4$s</string>
+    <string name="instance_batch_backup_failed_title">Ошибка пакетного копирования</string>
+    <string name="instance_batch_backup_failed_message">Не удалось создать резервные копии:\n%1$s</string>
+    <string name="instance_restore_title">Восстановить резервную копию</string>
+    <string name="instance_restore_in_progress">Восстановление резервной копии экземпляра…</string>
+    <string name="instance_restore_success_title">Восстановление завершено</string>
+    <string name="instance_restore_success_message">Восстановлено: %1$s</string>
+    <string name="instance_restore_failed_title">Ошибка восстановления</string>
+    <string name="instance_restore_failed_message">Не удалось восстановить резервную копию:\n%1$s</string>
 
-    <!-- Настройки языка -->
+    <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Язык (Language)</string>
     <string name="english">Английский (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -232,7 +322,7 @@
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
-    <!-- Переименовать версию -->
+    <!-- Version Rename -->
     <string name="rename_version_title">Переименовать версию</string>
     <string name="rename_version_message">Введите новое имя для этой версии:</string>
     <string name="new_version_name">Новое имя версии</string>
@@ -246,6 +336,13 @@
     <string name="worlds_title">Миры</string>
     <string name="resource_packs_title">Наборы ресурсов</string>
     <string name="behavior_packs_title">Наборы поведения</string>
+    <string name="skin_packs_title">Скин-паки</string>
+    <string name="worlds_category">Миры</string>
+    <string name="resource_packs_category">Наборы ресурсов</string>
+    <string name="behavior_packs_category">Наборы поведения</string>
+    <string name="skin_packs_category">Скин-паки</string>
+    <string name="screenshots_category">Скриншоты</string>
+    <string name="servers_category">Серверы</string>
     <string name="storage_internal">Внутренняя</string>
     <string name="storage_external">Внешняя</string>
     <string name="storage_version_isolation">Изоляция версии</string>
@@ -281,8 +378,8 @@
     <!-- Resource Pack Management -->
     <string name="import_resource_pack">Импортировать набор ресурсов</string>
     <string name="import_behavior_pack">Импортировать набор поведений</string>
-    <string name="delete_resource_pack">Удалить набор ресурсов</string>
     <string name="import_skin_pack">Импортировать скин-пак</string>
+    <string name="delete_resource_pack">Удалить набор ресурсов</string>
     <string name="delete_skin_pack">Удалить скин-пак</string>
     <string name="delete_behavior_pack">Удалить набор поведений</string>
 
@@ -305,6 +402,8 @@
     <string name="edit_world">Редактировать мир</string>
     <string name="edit">Редактировать</string>
     <string name="save">Сохранить</string>
+    <string name="reset">Сбросить</string>
+    <string name="saved_to_gallery">Сохранено в галерею</string>
     <string name="level_dat_not_found">Файл level.dat не найден</string>
     <string name="no_editable_properties">Редактируемые свойства не найдены</string>
     <string name="no_data">Нет данных</string>
@@ -328,6 +427,22 @@
     <string name="add_at_least_one_layer">Добавьте хотя бы один слой</string>
     <string name="world_created_successfully">Мир успешно создан</string>
     <string name="failed_to_create_world">Не удалось создать мир</string>
+    <string name="custom_flat_world_subtitle">Создайте мир со своим биомом и слоями блоков</string>
+    <string name="world_settings">Настройки мира</string>
+    <string name="world_settings_hint">Выберите основные настройки нового мира</string>
+    <string name="layers_title">Слои</string>
+    <string name="add_layer_compact">Добавить слой</string>
+    <string name="no_layers_title">Слоёв пока нет</string>
+    <string name="no_layers_hint">Добавьте хотя бы один слой блоков, чтобы создать мир</string>
+    <string name="reorder_layer">Изменить порядок слоя</string>
+    <string name="delete_layer">Удалить слой</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d слой • снизу → вверх</item>
+        <item quantity="few">%1$d слоя • снизу → вверх</item>
+        <item quantity="many">%1$d слоёв • снизу → вверх</item>
+        <item quantity="other">%1$d слоя • снизу → вверх</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Требуется версия из Play Маркета</string>
@@ -339,10 +454,57 @@
     <string name="genuine_badge_label">Лицензия не подтверждена</string>
     <string name="invalid_license_detected_toast">Обнаружена нелицензионная версия Minecraft. Убедитесь, что Minecraft установлен из Google Play Маркета</string>
 
-    <string name="full_mods_title">Моды </string>
+    <string name="full_mods_title">Моды</string>
     <string name="total_mods">Всего модов:</string>
     <string name="enabled_mods">Включено:</string>
     <string name="add_mod">Добавить мод</string>
+    <string name="scan_downloads">Сканировать</string>
+    <string name="scan_downloads_scanning">Сканирование…</string>
+    <string name="scan_downloads_none_found">В папке «Загрузки» не найдено модов .levipack или .so</string>
+    <string name="scan_downloads_failed">Не удалось просканировать папку «Загрузки»</string>
+    <string name="scan_downloads_permission_denied">Для сканирования папки «Загрузки» нужен доступ к хранилищу</string>
+    <string name="scan_downloads_results_title">Моды в папке «Загрузки»</string>
+    <string name="scan_downloads_results_subtitle">Выберите мод для добавления. Сканирование проверяет только основную папку «Загрузки».</string>
+    <string name="scan_downloads_add">Добавить</string>
+    <string name="scan_downloads_adding">Добавление…</string>
+    <string name="scan_downloads_added">Добавлено</string>
+    <string name="scan_downloads_added_message">%1$s добавлен</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Нативная библиотека</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Внешние моды</string>
+    <string name="external_mods_subtitle">Моды сообщества для Minecraft %1$s</string>
+    <string name="external_mods_no_version">Выберите версию Minecraft перед установкой модов</string>
+    <string name="external_mods_search_hint">Поиск модов, авторов или версий…</string>
+    <string name="external_mods_compatible_only">Только совместимые</string>
+    <string name="external_mods_all_versions">Все версии Minecraft</string>
+    <string name="external_mods_sort_newest">Сначала новые</string>
+    <string name="external_mods_sort_name">Название А–Я</string>
+    <string name="external_mods_empty">Нет модов, соответствующих этим фильтрам</string>
+    <string name="external_mods_load_failed">Не удалось обновить каталог. Показана сохранённая копия.</string>
+    <string name="external_mods_refresh">Обновить каталог</string>
+    <string name="external_mods_refreshed">Каталог обновлён</string>
+    <string name="external_mods_join_discord">Присоединиться к Discord сообщества</string>
+    <string name="external_mods_discord_open_failed">Нет приложения, которое может открыть приглашение Discord</string>
+    <string name="external_mods_download">Загрузка %1$s</string>
+    <string name="external_mods_importing">Импорт мода…</string>
+    <string name="external_mods_installed">%1$s установлен</string>
+    <string name="external_mods_install_failed">Не удалось установить %1$s: %2$s</string>
+    <string name="external_mods_open_failed">Нет браузера, который может открыть эту загрузку</string>
+    <string name="external_mods_direct_download">Прямая загрузка</string>
+    <string name="external_mods_ad_download">Загрузка с рекламой</string>
+    <string name="external_mods_external_link">Внешняя ссылка</string>
+    <string name="external_mods_open_link">Открыть ссылку</string>
+    <string name="external_mods_external_dialog_title">Внешняя загрузка</string>
+    <string name="external_mods_ad_dialog_title">Загрузка с рекламой</string>
+    <string name="external_mods_external_dialog_message">%1$s использует страницу загрузки вне LeviLauncher.\n\n1. Нажмите «Открыть ссылку» и скачайте файл .levipack или .so.\n2. Вернитесь в LeviLauncher и откройте «Моды».\n3. Нажмите «Сканировать».\n4. Нажмите «Добавить» рядом с модом, который хотите импортировать.\n\nСканирование проверяет только основную папку «Загрузки». Переместите файл туда, если браузер сохранил его в другом месте.</string>
+    <string name="external_mods_ad_dialog_message">%1$s использует страницу загрузки с рекламой, выбранную разработчиком. LeviLauncher не контролирует эту страницу или размещённую на ней рекламу.\n\n1. Нажмите «Открыть ссылку» и скачайте файл .levipack или .so.\n2. Вернитесь в LeviLauncher и откройте «Моды».\n3. Нажмите «Сканировать».\n4. Нажмите «Добавить» рядом с модом, который хотите импортировать.\n\nСканирование проверяет только основную папку «Загрузки». Скачивайте только файл мода; не устанавливайте посторонние приложения и не разрешайте уведомления.</string>
+    <string name="external_mods_by_author">от %1$s</string>
+    <string name="external_mods_version">Мод %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Обновить</string>
+    <string name="external_mods_installed_button">Установлено</string>
+    <string name="external_mods_incompatible">Несовместимо</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">Детали мода</string>
@@ -352,12 +514,63 @@
     <string name="mod_disabled">Мод отключен</string>
     <string name="mod_filename_format">Файл: %s</string>
     <string name="mod_enable_status">Состояние включения</string>
+    <string name="mod_icon_content_description">Значок мода</string>
+    <string name="mod_author_byline">от %s</string>
+    <string name="mod_version_chip">Версия %s</string>
+    <string name="mod_metadata_title">Информация</string>
+    <string name="mod_actions_title">Действия</string>
+    <string name="mod_author_label">Автор</string>
+    <string name="mod_version_label">Версия</string>
+    <string name="mod_minecraft_versions_label">Версии Minecraft</string>
+    <string name="mod_entry_label">Файл входа</string>
+    <string name="mod_id_label">ID мода</string>
+    <string name="mod_config_files_label">Файлы конфигурации</string>
+    <string name="mod_unknown_author">Неизвестный автор</string>
+    <string name="mod_unknown_version">Неизвестная версия</string>
+    <string name="mod_all_versions">Все поддерживаемые версии</string>
+    <string name="mod_no_config_files">Нет редактируемой конфигурации</string>
+    <string name="mod_config_badge">КОНФИГ</string>
+    <string name="mod_config_badge_with_count">КОНФИГ · %d</string>
+    <string name="mod_config_title_format">Конфигурация %s</string>
+    <string name="mod_config_not_found">Редактируемая конфигурация не найдена</string>
+    <string name="mod_config_load_failed">Не удалось загрузить конфигурацию: %s</string>
+    <string name="mod_config_save_failed">Не удалось сохранить конфигурацию</string>
+    <string name="mod_config_saved">Конфигурация сохранена</string>
+    <string name="mod_config_restart_hint">Файл конфигурации сохранен, файл .backup оставлен.</string>
+    <string name="mod_config_validation_failed">Проверка конфигурации не пройдена</string>
+    <string name="mod_config_invalid_json">Недопустимый JSON</string>
+    <string name="mod_config_expand">Развернуть</string>
+    <string name="mod_config_collapse">Свернуть</string>
+    <string name="mod_config_raw_json">Редактировать исходный JSON</string>
+    <string name="mod_config_raw_json_short">JSON</string>
+    <string name="mod_config_item_label">Элемент %1$s</string>
+    <string name="mod_config_object_desc">Группа связанных настроек</string>
+    <string name="mod_config_array_desc">Список значений</string>
+    <string name="mod_config_range_prefix">Диапазон</string>
+    <string name="mod_config_error_number">%1$s должно быть числом</string>
+    <string name="mod_config_error_minimum">%1$s должно быть не меньше %2$s</string>
+    <string name="mod_config_error_maximum">%1$s должно быть не больше %2$s</string>
+    <string name="mod_config_error_boolean">%1$s должно быть включено или выключено</string>
+    <string name="mod_config_error_string">%1$s должно быть текстом</string>
+    <!-- Mod Configuration -->
+    <plurals name="mod_config_files_count">
+        <item quantity="one">%d редактируемая конфигурация</item>
+        <item quantity="other">%d редактируемой конфигурации</item>
+    </plurals>
+    <plurals name="mod_config_choices_count">
+        <item quantity="one">%d вариант</item>
+        <item quantity="other">%d варианта</item>
+    </plurals>
+    <plurals name="mod_config_items_count">
+        <item quantity="one">%d элемент</item>
+        <item quantity="other">%d элемента</item>
+    </plurals>
 
-    <!-- Диалог выбора версии игры -->
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">Выбор версии игры</string>
     <string name="back">Назад</string>
 
-    <!-- Заставка -->
+    <!-- Splash -->
     <string name="splash_logo_desc">Логотип листа</string>
     <string name="minecraft_loading_title">Запуск Minecraft</string>
     <string name="minecraft_loading_subtitle">Подготовка native-библиотек и включенных модов</string>
@@ -382,13 +595,45 @@
     <string name="accounts_active_privilege">Выполнен вход</string>
 
     <string name="ms_login_title">Вход Microsoft</string>
+    <string name="ms_login_header_subtitle">Безопасный вход в Minecraft</string>
     <string name="ms_login_starting">Начинается вход в Microsoft…</string>
     <string name="ms_login_exchanging">Обмен токеном…</string>
     <string name="ms_login_auth_xbox_device">Аутентификация устройства Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Получение идентификатора Minecraft…</string>
+    <string name="ms_login_retrying">Соединение прервано. Безопасная повторная попытка…</string>
     <string name="ms_login_success">Выполнен вход как %1$s</string>
     <string name="ms_login_failed">Сбой входа в Microsoft</string>
     <string name="ms_login_failed_detail">Сбой входа: %1$s</string>
+    <string name="ms_choose_login_method">Войти в Minecraft</string>
+    <string name="ms_choose_login_method_desc">Выберите вход по коду устройства через браузер или продолжите на встроенной странице Microsoft.</string>
+    <string name="ms_device_code_login">Продолжить в браузере</string>
+    <string name="ms_device_code_option_title">Код устройства (рекомендуется)</string>
+    <string name="ms_device_code_login_desc">Открыть приватный сеанс браузера с уже введённым кодом устройства.</string>
+    <string name="ms_webview_login">Открыть встроенный вход</string>
+    <string name="ms_webview_option_title">Встроенный WebView</string>
+    <string name="ms_webview_login_desc">Войдите, не покидая LeviLauncher. Используйте этот вариант, если вход через браузер недоступен.</string>
+    <string name="ms_device_code_title">Вход по коду устройства</string>
+    <string name="ms_device_code_instructions">Откройте страницу входа Microsoft по коду устройства, введите этот код и разрешите доступ. LeviLauncher завершит вход автоматически.</string>
+    <string name="ms_device_code_label">Код устройства Microsoft</string>
+    <string name="ms_device_code_requesting">Запрос защищённого кода…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Ожидание завершения в браузере…</string>
+    <string name="ms_device_code_checking">Проверка результата входа Microsoft…</string>
+    <string name="ms_device_code_reconnecting">Соединение изменилось. Автоматическая повторная попытка…</string>
+    <string name="ms_device_code_authorized">Microsoft подтвердил вход. Завершение…</string>
+    <string name="ms_device_code_browser_opened">Завершите новый вход в Microsoft в браузере, затем вернитесь сюда.</string>
+    <string name="ms_device_code_expires">Код истекает через %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Скопировать код</string>
+    <string name="ms_device_code_copied">Код скопирован</string>
+    <string name="ms_device_code_open_browser">Открыть вход Microsoft</string>
+    <string name="ms_device_code_step_title">Завершите вход в браузере</string>
+    <string name="ms_device_code_browser_note">LeviLauncher открывает браузер по умолчанию в приватном сеансе, автоматически вводит код и запрашивает новый вход в Microsoft.</string>
+    <string name="ms_choose_other_method">Другой способ</string>
+    <string name="ms_no_browser">На этом устройстве нет доступного браузера.</string>
+    <string name="ms_default_browser_no_private_mode">Ваш браузер по умолчанию не поддерживает приватный вход. Обновите его или используйте вход через WebView.</string>
+    <string name="ms_login_ssl_failed">Не удалось проверить защищённую страницу входа Microsoft.</string>
+    <string name="ms_login_state_failed">Не удалось проверить ответ Microsoft при входе. Начните вход заново.</string>
+    <string name="ms_login_missing_code">Microsoft не вернул код входа. Начните вход заново или используйте код устройства.</string>
 
     <string name="ms_set_active">Сделать активным</string>
     <string name="ms_delete">Удалить</string>
@@ -401,10 +646,14 @@
     <string name="go_to_accounts">Аккаунты</string>
     <string name="disable_launcher_login_and_continue">Закрыть</string>
 
+    <string name="ms_feature_disabled_title">Функция отключена</string>
+    <string name="ms_feature_disabled_desc">Включите «Вход в Minecraft через LeviLauncher» в настройках, чтобы управлять учётными записями Microsoft.</string>
+    <string name="ms_activated">Активировано</string>
+
     <!-- Popup labels -->
     <string name="label_current_account">Текущий аккаунт</string>
     <string name="label_other_accounts">Другие аккаунты</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">Приложение аварийно завершило работу</string>
     <string name="crash_upload">Загрузить отчет о сбое</string>
     <string name="crash_details_title">Сведения о сбое</string>
@@ -422,11 +671,16 @@
     <string name="dialog_title_exit_app">Выйти из приложения</string>
     <string name="dialog_message_exit_app">Вы уверены, что хотите выйти?</string>
     <string name="dialog_positive_exit">Выйти</string>
-
-    <!-- Logcat Overlay i18n -->
     <string name="show_logcat_overlay">Оверлей Logcat</string>
+    <string name="foreground_service">Служба переднего плана</string>
+    <string name="foreground_service_desc">Оставляет Minecraft запущенным при переключении между приложениями: не даёт Bedrock приостановить активный сеанс и поддерживает активность процесса, процессора и Wi-Fi.</string>
+    <string name="foreground_service_warning">Примечание: телефон может нагреваться быстрее, а расход батареи может увеличиться.</string>
+    <string name="foreground_service_channel">Защита Minecraft в фоновом режиме</string>
+    <string name="foreground_service_notification_title">Minecraft поддерживается активным</string>
+    <string name="foreground_service_notification_text">Фоновый режим Minecraft активен. Процессор и доступ к сети остаются доступными для текущего сеанса.</string>
     <string name="logcat_live">Logcat: <b>в реальном времени</b></string>
     <string name="logcat_paused">Logcat: приостановлен</string>
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">Фильтр по ключевым словам</string>
     <string name="logcat_blacklist_hint">Чёрный список (через запятую)</string>
     <string name="logcat_filter_clear">Сбросить фильтры</string>
@@ -447,7 +701,7 @@
     <string name="inbuilt_mod_removed">%s удален из модов</string>
     <string name="add">Добавить</string>
     <string name="remove">Удалить</string>
-
+    
     <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">Быстрый сброс</string>
     <string name="inbuilt_mod_quick_drop_desc">Быстрое выбрасывание предметов</string>
@@ -471,12 +725,25 @@
     <string name="inbuilt_mod_cps_display_desc">Показывает количество кликов в секунду</string>
     <string name="inbuilt_mod_snaplook">Быстрый взгляд назад</string>
     <string name="inbuilt_mod_snaplook_desc">Удерживайте для быстрого взгляда назад (вид спереди от третьего лица)</string>
+    <string name="inbuilt_mod_virtual_cursor">Виртуальный курсор</string>
+    <string name="inbuilt_mod_virtual_cursor_desc">Используйте виртуальный трекпад для управления мышью</string>
+    <string name="virtual_cursor_enabled">Курсор включён</string>
+    <string name="virtual_cursor_disabled">Курсор отключён</string>
+    <string name="cursor_sensitivity_label">Чувствительность курсора:</string>
+    <string name="inbuilt_mod_gyro">Гироскоп</string>
+    <string name="inbuilt_mod_gyro_desc">Использовать гироскоп устройства для управления вращением камеры</string>
+    <string name="inbuilt_mod_pojav_controls">Управление Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Заменить сенсорное управление Minecraft полностью настраиваемым управлением в стиле Pojav</string>
+    <string name="inbuilt_mod_more_buttons">Дополнительные кнопки</string>
+    <string name="inbuilt_mod_more_buttons_desc">Создавайте пользовательские экранные кнопки с назначением одной клавиши и SVG-значками</string>
     <string name="inbuilt_badge">ВСТРОЕН</string>
     <string name="autosprint_keybind_label">Клавиша авто-спринта:</string>
     <string name="autosprint_keybind_press">Нажмите любую клавишу…</string>
     <string name="configure">Настроить</string>
     <string name="overlay_button_size">Размер кнопки наложения</string>
     <string name="overlay_button_opacity">Прозрачность кнопки</string>
+    <string name="overlay_button_size_value">Размер: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Непрозрачность: %1$d%%</string>
     <string name="overlay_button_lock">Заблокировать положение</string>
     <string name="overlay_button_lock_desc">Запретить перетаскивание и случайные нажатия</string>
     <string name="settings">Настройки</string>
@@ -498,13 +765,33 @@
     <!-- Mod Menu -->
     <string name="mod_menu">Мод-меню</string>
     <string name="mod_menu_modules">Модули</string>
+    <string name="mod_menu_favorites">Избранное</string>
+    <string name="mod_menu_favorite">Добавить в избранное</string>
+    <string name="mod_menu_unfavorite">Удалить из избранного</string>
+    <string name="mod_menu_hud_editor">Редактор HUD</string>
+    <string name="mod_menu_filter_enabled">Включённые</string>
+    <string name="mod_menu_filter_inbuilt">Встроенные</string>
+    <string name="mod_menu_filter_external">Внешние</string>
     <string name="mod_menu_search_hint">Поиск модов…</string>
     <string name="mod_menu_no_mods">Моды не добавлены</string>
+    <string name="mod_menu_no_favorites">Избранных модов пока нет</string>
+    <string name="mod_menu_no_matches">Подходящих модов нет</string>
+    <string name="mod_menu_group_inbuilt">Встроенные функции</string>
+    <string name="mod_menu_group_external_ungrouped">Несгруппированные внешние моды</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Общие настройки</string>
+    <string name="mod_menu_appearance">Внешний вид</string>
+    <string name="mod_menu_pause_menu_only">Только меню паузы</string>
+    <string name="mod_menu_pause_menu_only_desc">Показывать меню модов только на экране паузы</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Настройки скоро появятся</string>
     <string name="mod_menu_notifications">Уведомления</string>
     <string name="mod_menu_notifications_desc">Показывать уведомление при включении модов</string>
     <string name="mod_menu_opacity">Прозрачность мод-меню</string>
     <string name="mod_menu_button_opacity">Прозрачность кнопки мод-меню</string>
+    <string name="mod_menu_compact">Компактное меню модов</string>
+    <string name="mod_menu_compact_desc">Использовать уменьшенное меню с плотным списком модулей и компактными фильтрами</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Мод-меню включено</string>
     <string name="mod_menu_disabled">Мод-меню выключено</string>
@@ -513,6 +800,35 @@
     <string name="mod_status_enabled">Включено</string>
     <string name="mod_status_disabled">Выключено</string>
     <string name="mod_notification_enabled">%s включено</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Размер кнопки оверлея (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Непрозрачность оверлея (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Показывать везде</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Чувствительность курсора (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Уровень зума (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Клавиша автоспринта</string>
+    <string name="mod_config_zoom_keybind">Клавиша зума</string>
+    <string name="mod_config_zoom_transition">Длительность перехода (мс)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Множитель чувствительности (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Горизонтальная скорость (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Вертикальная скорость (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Фильтр малых движений (0 = выкл.)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Горизонтальная чувствительность (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Вертикальная чувствительность (%)</string>
+    <string name="mod_config_gyro_invert_x">Инвертировать горизонтальную ось</string>
+    <string name="mod_config_gyro_invert_y">Инвертировать вертикальную ось</string>
+    <string name="mod_config_gyro_deadzone">Мёртвая зона</string>
+    <string name="mod_config_press_any_key">Нажмите любую клавишу для привязки...</string>
+    <string name="mod_config_key_unknown">НЕИЗВЕСТНО</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Перетащите, чтобы переместить панель</string>
+    <string name="hud_editor_drag_description">Редактор HUD. Перетащите эту область, чтобы переместить панель.</string>
 
     <!-- Options Editor -->
     <string name="edit_options">Редактировать настройки</string>
@@ -592,74 +908,13 @@
     <string name="curseforge_download_failed">Ошибка скачивания</string>
     <string name="curseforge_available_files">Доступные файлы</string>
 
-    <!-- Missing translations -->
-    <string name="cursor">Курсор</string>
-    <string name="bedrock_edition">Bedrock Edition</string>
-    <string name="current_instance">Текущий экземпляр</string>
-    <string name="content_mgmt_section_title">Управление контентом</string>
-    <string name="misc_section_title">Разное</string>
-    <string name="view_all">Показать все →</string>
-    <string name="import_so_plugin_title">Импорт SO-плагина</string>
-    <string name="plugin_name_label">Название плагина</string>
-    <string name="plugin_type_label">Тип</string>
-    <string name="plugin_version_label">Версия</string>
-    <string name="import_button">Импорт</string>
-    <string name="settings_subtitle">Настройка основных параметров лаунчера</string>
-    <string name="settings_tab_basic">Основные настройки</string>
-    <string name="settings_tab_personalize">Персонализация</string>
-    <string name="settings_tab_updates">Обновления</string>
-    <string name="settings_tab_about">О приложении</string>
-    <string name="settings_tab_migration">Миграция</string>
-    <string name="settings_theme_desc">Выберите тему приложения</string>
-    <string name="launch_vertically">Запуск вертикально</string>
-    <string name="launch_vertically_desc">Принудительно запускать игру в портретном режиме</string>
-    <string name="instance_settings_title">Настройки экземпляра</string>
-    <string name="instance_tab_general">Общие</string>
-    <string name="instance_tab_launch_options">Параметры запуска</string>
-    <string name="instance_tab_management">Управление</string>
-    <string name="instance_new_name">Новое имя</string>
-    <string name="instance_rename_hint">Переименовывается только папка. Версия и тип игры не изменяются.</string>
-    <string name="instance_custom_icon">Пользовательский значок (требуется квадрат)</string>
-    <string name="instance_clear_icon">Очистить</string>
-    <string name="instance_icon_hint">Будет сохранён как LargeLogo.png в папке версии. Нажмите на значок, чтобы изменить.</string>
-    <string name="instance_isolation_desc">Изолировать игровые данные для этого экземпляра. Другие экземпляры не будут затронуты.</string>
-    <string name="instance_danger_zone">Опасная зона</string>
-    <string name="instance_danger_zone_desc">Эти действия влияют на регистрацию экземпляра или локальные файлы. Проверьте всё перед продолжением.</string>
-    <string name="instance_delete_desc">Навсегда удаляет этот экземпляр с устройства, включая миры, настройки и установленный контент.</string>
-    <string name="instance_delete_warning">Это действие нельзя отменить.</string>
-    <string name="instance_delete_confirm_title">Удалить экземпляр</string>
-    <string name="instance_delete_confirm_msg">Вы уверены, что хотите удалить этот экземпляр? Все данные, включая миры, будут удалены навсегда.</string>
-    <string name="instance_batch_backup_button">Пакетная копия</string>
-    <string name="instance_batch_backup_title">Пакетное резервное копирование экземпляров</string>
-    <string name="instance_batch_backup_select_message">Выберите экземпляры для резервного копирования. Если Minecraft запущен, сначала выйдите из игры, чтобы избежать изменения данных во время копирования.</string>
-    <string name="instance_batch_backup_select_all">Выбрать все экземпляры</string>
-    <string name="instance_batch_backup_no_instances">Нет экземпляров, доступных для резервного копирования.</string>
-    <string name="instance_batch_backup_no_selection">Выберите хотя бы один экземпляр.</string>
-    <string name="instance_batch_backup_in_progress">Резервное копирование %1$s (%2$d/%3$d)…</string>
-    <string name="instance_batch_backup_success_title">Резервные копии созданы</string>
-    <string name="instance_batch_backup_success_message">Создано резервных копий: %1$d\n%2$s</string>
-    <string name="instance_batch_backup_partial_title">Резервное копирование частично завершено</string>
-    <string name="instance_batch_backup_partial_message">Создано резервных копий: %1$d, ошибок: %2$d.\n\nСохранено:\n%3$s\n\nОшибки:\n%4$s</string>
-    <string name="instance_batch_backup_failed_title">Ошибка пакетного копирования</string>
-    <string name="instance_batch_backup_failed_message">Не удалось создать резервные копии:\n%1$s</string>
-    <string name="skin_packs_title">Скин-паки</string>
-    <string name="worlds_category">Миры</string>
-    <string name="resource_packs_category">Наборы ресурсов</string>
-    <string name="behavior_packs_category">Наборы поведения</string>
-    <string name="skin_packs_category">Скин-паки</string>
-    <string name="screenshots_category">Скриншоты</string>
-    <string name="servers_category">Серверы</string>
-    <string name="saved_to_gallery">Сохранено в галерею</string>
-    <string name="inbuilt_mod_virtual_cursor">Виртуальный курсор</string>
-    <string name="inbuilt_mod_virtual_cursor_desc">Используйте виртуальный трекпад для управления мышью</string>
-    <string name="virtual_cursor_enabled">Курсор включён</string>
-    <string name="virtual_cursor_disabled">Курсор отключён</string>
-    <string name="cursor_sensitivity_label">Чувствительность курсора:</string>
+    <!-- Navigation Bar -->
     <string name="nav_launch">Запуск</string>
     <string name="nav_import">Импорт</string>
     <string name="nav_instances">Экземпляры</string>
     <string name="nav_about">О приложении</string>
     <string name="nav_settings">Настройки</string>
+
     <string name="search_instances_hint">Поиск…</string>
     <string name="instances_label">Экземпляры</string>
     <string name="select_instance_title">Выбрать экземпляр</string>
@@ -669,6 +924,7 @@
     <string name="tag_installed">Установлено</string>
     <string name="tag_custom">Пользовательская</string>
     <string name="vanilla_prefix">Vanilla %s</string>
+
     <string name="about_page_title">О приложении</string>
     <string name="about_subtitle">LeviLauncher — современный лаунчер Minecraft Bedrock</string>
     <string name="about_authors_title">👥 Авторы и сопровождающие</string>
@@ -685,6 +941,7 @@
     <string name="about_contribute_desc">Вклад через Issues или Pull Requests приветствуется и помогает улучшать LeviLauncher.</string>
     <string name="about_issues">Issue</string>
     <string name="about_star_fork">Star / Fork</string>
+
     <string-array name="launcher_tips">
         <item>В настройках можно изменить тему, цвет, фон и другие параметры внешнего вида под ваш стиль.</item>
         <item>LeviLauncher имеет открытый исходный код. Используйте GitHub issues, чтобы сообщить о проблемах лаунчера или предложить улучшения.</item>
@@ -698,6 +955,7 @@
         <item>CurseForge позволяет просматривать и загружать контент сообщества напрямую.</item>
         <item>Загружайте внешние нативные SO-модули, чтобы расширять или улучшать возможности и производительность Minecraft.</item>
     </string-array>
+    <!-- Personalization -->
     <string name="theme_color_title">Цвет темы</string>
     <string name="theme_color_desc">Основной акцентный цвет приложения</string>
     <string name="preset_colors">ГОТОВЫЕ ЦВЕТА</string>
@@ -715,169 +973,8 @@
 
     <string name="unsupported_version_title">Неподдерживаемая версия</string>
     <string name="unsupported_version_msg">Этот лаунчер не поддерживает версии Minecraft старше 1.21.80.</string>
-    <!-- Mod Config -->
-    <string name="mod_author_byline">от %s</string>
-    <string name="mod_version_chip">Версия %s</string>
-    <string name="mod_config_title_format">Конфигурация %s</string>
-    <string name="mod_config_not_found">Редактируемая конфигурация не найдена</string>
-    <string name="mod_config_load_failed">Не удалось загрузить конфигурацию: %s</string>
-    <string name="mod_config_save_failed">Не удалось сохранить конфигурацию</string>
-    <string name="mod_config_saved">Конфигурация сохранена</string>
-    <string name="mod_config_restart_hint">Файл конфигурации сохранен, файл .backup оставлен.</string>
-    <string name="mod_config_validation_failed">Проверка конфигурации не пройдена</string>
-    <string name="mod_config_invalid_json">Недопустимый JSON</string>
-    <string name="mod_config_expand">Развернуть</string>
-    <string name="mod_config_collapse">Свернуть</string>
-    <string name="mod_config_raw_json">Редактировать исходный JSON</string>
-    <string name="mod_config_raw_json_short">JSON</string>
-    <string name="mod_config_item_label">Элемент %1$s</string>
-    <string name="mod_config_object_desc">Группа связанных настроек</string>
-    <string name="mod_config_array_desc">Список значений</string>
-    <string name="mod_config_range_prefix">Диапазон</string>
-    <string name="mod_config_error_number">%1$s должно быть числом</string>
-    <string name="mod_config_error_minimum">%1$s должно быть не меньше %2$s</string>
-    <string name="mod_config_error_maximum">%1$s должно быть не больше %2$s</string>
-    <string name="mod_config_error_boolean">%1$s должно быть включено или выключено</string>
-    <string name="mod_config_error_string">%1$s должно быть текстом</string>
-    <plurals name="mod_config_files_count">
-        <item quantity="one">%d редактируемая конфигурация</item>
-        <item quantity="few">%d редактируемые конфигурации</item>
-        <item quantity="many">%d редактируемых конфигураций</item>
-        <item quantity="other">%d редактируемой конфигурации</item>
-    </plurals>
-    <plurals name="mod_config_choices_count">
-        <item quantity="one">%d вариант</item>
-        <item quantity="few">%d варианта</item>
-        <item quantity="many">%d вариантов</item>
-        <item quantity="other">%d варианта</item>
-    </plurals>
-    <plurals name="mod_config_items_count">
-        <item quantity="one">%d элемент</item>
-        <item quantity="few">%d элемента</item>
-        <item quantity="many">%d элементов</item>
-        <item quantity="other">%d элемента</item>
-    </plurals>
 
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Избранное</string>
-    <string name="mod_menu_favorite">Добавить в избранное</string>
-    <string name="mod_menu_unfavorite">Удалить из избранного</string>
-    <string name="mod_menu_hud_editor">Редактор HUD</string>
-    <string name="mod_menu_filter_enabled">Включённые</string>
-    <string name="mod_menu_filter_inbuilt">Встроенные</string>
-    <string name="mod_menu_filter_external">Внешние</string>
-    <string name="mod_menu_no_favorites">Избранных модов пока нет</string>
-    <string name="mod_menu_no_matches">Подходящих модов нет</string>
-    <string name="mod_menu_group_inbuilt">Встроенные функции</string>
-    <string name="mod_menu_group_external_ungrouped">Несгруппированные внешние моды</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Общие настройки</string>
-    <string name="mod_menu_appearance">Внешний вид</string>
-    <string name="mod_menu_pause_menu_only">Только меню паузы</string>
-    <string name="mod_menu_pause_menu_only_desc">Показывать меню модов только на экране паузы</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Размер кнопки оверлея (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Непрозрачность оверлея (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Чувствительность курсора (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Уровень зума (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Клавиша автоспринта</string>
-    <string name="mod_config_zoom_keybind">Клавиша зума</string>
-    <string name="mod_config_press_any_key">Нажмите любую клавишу для привязки...</string>
-    <string name="mod_config_key_unknown">НЕИЗВЕСТНО</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Размер: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Непрозрачность: %1$d%%</string>
-    <string name="reset">Сбросить</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Удалить учётную запись</string>
-    <string name="delete_account_confirm">Вы уверены, что хотите удалить эту учётную запись?</string>
-    <string name="instance_backup_title">Резервная копия экземпляра</string>
-    <string name="instance_backup_desc">Создать полную резервную копию этого экземпляра в Download/LeviLauncher/Backups.</string>
-    <string name="instance_backup_button">Создать резервную копию экземпляра</string>
-    <string name="instance_backup_confirm_message">Создать полную резервную копию этого экземпляра сейчас? Если Minecraft запущен, сначала закройте его, чтобы файлы не менялись во время резервного копирования.</string>
-    <string name="instance_backup_in_progress">Создание резервной копии экземпляра…</string>
-    <string name="instance_backup_success_title">Резервная копия создана</string>
-    <string name="instance_backup_success_message">Резервная копия сохранена в:\n%1$s</string>
-    <string name="instance_backup_failed_title">Ошибка резервного копирования</string>
-    <string name="instance_backup_failed_message">Не удалось создать резервную копию:\n%1$s</string>
-    <string name="instance_import_backup_button">Импортировать резервную копию</string>
-    <string name="instance_restore_title">Восстановить резервную копию</string>
-    <string name="instance_restore_in_progress">Восстановление резервной копии экземпляра…</string>
-    <string name="instance_restore_success_title">Восстановление завершено</string>
-    <string name="instance_restore_success_message">Восстановлено: %1$s</string>
-    <string name="instance_restore_failed_title">Ошибка восстановления</string>
-    <string name="instance_restore_failed_message">Не удалось восстановить резервную копию:\n%1$s</string>
-    <string name="mod_icon_content_description">Значок мода</string>
-    <string name="mod_metadata_title">Информация</string>
-    <string name="mod_actions_title">Действия</string>
-    <string name="mod_author_label">Автор</string>
-    <string name="mod_version_label">Версия</string>
-    <string name="mod_minecraft_versions_label">Версии Minecraft</string>
-    <string name="mod_entry_label">Файл входа</string>
-    <string name="mod_id_label">ID мода</string>
-    <string name="mod_config_files_label">Файлы конфигурации</string>
-    <string name="mod_unknown_author">Неизвестный автор</string>
-    <string name="mod_unknown_version">Неизвестная версия</string>
-    <string name="mod_all_versions">Все поддерживаемые версии</string>
-    <string name="mod_no_config_files">Нет редактируемой конфигурации</string>
-    <string name="mod_config_badge">КОНФИГ</string>
-    <string name="mod_config_badge_with_count">КОНФИГ · %d</string>
-    <string name="ms_login_header_subtitle">Безопасный вход в Minecraft</string>
-    <string name="ms_login_retrying">Соединение прервано. Безопасная повторная попытка…</string>
-    <string name="ms_choose_login_method">Войти в Minecraft</string>
-    <string name="ms_choose_login_method_desc">Выберите вход по коду устройства через браузер или продолжите на встроенной странице Microsoft.</string>
-    <string name="ms_device_code_login">Продолжить в браузере</string>
-    <string name="ms_device_code_option_title">Код устройства (рекомендуется)</string>
-    <string name="ms_device_code_login_desc">Открыть приватный сеанс браузера с уже введённым кодом устройства.</string>
-    <string name="ms_webview_login">Открыть встроенный вход</string>
-    <string name="ms_webview_option_title">Встроенный WebView</string>
-    <string name="ms_webview_login_desc">Войдите, не покидая LeviLauncher. Используйте этот вариант, если вход через браузер недоступен.</string>
-    <string name="ms_device_code_title">Вход по коду устройства</string>
-    <string name="ms_device_code_instructions">Откройте страницу входа Microsoft по коду устройства, введите этот код и разрешите доступ. LeviLauncher завершит вход автоматически.</string>
-    <string name="ms_device_code_label">Код устройства Microsoft</string>
-    <string name="ms_device_code_requesting">Запрос защищённого кода…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Ожидание завершения в браузере…</string>
-    <string name="ms_device_code_checking">Проверка результата входа Microsoft…</string>
-    <string name="ms_device_code_reconnecting">Соединение изменилось. Автоматическая повторная попытка…</string>
-    <string name="ms_device_code_authorized">Microsoft подтвердил вход. Завершение…</string>
-    <string name="ms_device_code_browser_opened">Завершите новый вход в Microsoft в браузере, затем вернитесь сюда.</string>
-    <string name="ms_device_code_expires">Код истекает через %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Скопировать код</string>
-    <string name="ms_device_code_copied">Код скопирован</string>
-    <string name="ms_device_code_open_browser">Открыть вход Microsoft</string>
-    <string name="ms_device_code_step_title">Завершите вход в браузере</string>
-    <string name="ms_device_code_browser_note">LeviLauncher открывает браузер по умолчанию в приватном сеансе, автоматически вводит код и запрашивает новый вход в Microsoft.</string>
-    <string name="ms_choose_other_method">Другой способ</string>
-    <string name="ms_no_browser">На этом устройстве нет доступного браузера.</string>
-    <string name="ms_default_browser_no_private_mode">Ваш браузер по умолчанию не поддерживает приватный вход. Обновите его или используйте вход через WebView.</string>
-    <string name="ms_login_ssl_failed">Не удалось проверить защищённую страницу входа Microsoft.</string>
-    <string name="ms_login_state_failed">Не удалось проверить ответ Microsoft при входе. Начните вход заново.</string>
-    <string name="ms_login_missing_code">Microsoft не вернул код входа. Начните вход заново или используйте код устройства.</string>
-    <string name="ms_feature_disabled_title">Функция отключена</string>
-    <string name="ms_feature_disabled_desc">Включите «Вход в Minecraft через LeviLauncher» в настройках, чтобы управлять учётными записями Microsoft.</string>
-    <string name="ms_activated">Активировано</string>
-    <string name="inbuilt_mod_gyro">Гироскоп</string>
-    <string name="inbuilt_mod_gyro_desc">Использовать гироскоп устройства для управления вращением камеры</string>
-    <string name="inbuilt_mod_pojav_controls">Управление Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Заменить сенсорное управление Minecraft полностью настраиваемым управлением в стиле Pojav</string>
-    <string name="inbuilt_mod_more_buttons">Дополнительные кнопки</string>
-    <string name="inbuilt_mod_more_buttons_desc">Создавайте пользовательские экранные кнопки с назначением одной клавиши и SVG-значками</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Показывать везде</string>
-    <string name="mod_config_zoom_transition">Длительность перехода (мс)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Горизонтальная чувствительность (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Вертикальная чувствительность (%)</string>
-    <string name="mod_config_gyro_invert_x">Инвертировать горизонтальную ось</string>
-    <string name="mod_config_gyro_invert_y">Инвертировать вертикальную ось</string>
-    <string name="mod_config_gyro_deadzone">Мёртвая зона</string>
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Закрыть</string>
     <string name="previous">Назад</string>
     <string name="next">Далее</string>
@@ -927,6 +1024,8 @@
     <string name="custom_color_hint">#RRGGBB или R,G,B</string>
     <string name="screenshot_name_placeholder">Название снимка экрана</string>
     <string name="screenshot_date_placeholder">Дата: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Создавайте экранные кнопки в стиле Minecraft, каждая из которых назначена ровно на одну клавишу клавиатуры. Кнопки никогда не выполняют макросы, последовательности клавиш, автоматические повторы или автоклик.</string>
     <string name="more_buttons_add_button">Добавить кнопку</string>
     <string name="more_buttons_limit_reached">Достигнут максимум пользовательских кнопок: %1$d.</string>
@@ -984,99 +1083,17 @@
     <string name="more_buttons_no_svg_selected">SVG не выбран</string>
     <string name="more_buttons_default_name">Кнопка</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Слот панели быстрого доступа</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Добавляет отдельные кнопки 1–9 для выбора слотов панели быстрого доступа</string>
     <string name="hotbar_slot_content_description">Слот панели быстрого доступа %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Ярлык на главном экране</string>
-    <string name="instance_shortcut_desc">Изменения имени и значка сохраняются автоматически. Нажмите «Добавить ярлык», чтобы создать или обновить ярлык на главном экране.</string>
-    <string name="instance_shortcut_name">Название ярлыка</string>
-    <string name="instance_shortcut_icon">Значок ярлыка</string>
-    <string name="instance_shortcut_choose_icon">Выбрать значок</string>
-    <string name="instance_shortcut_default_icon">Использовать стандартный</string>
-    <string name="instance_shortcut_add_button">Добавить ярлык</string>
-    <string name="instance_settings_auto_save_failed">Не удалось сохранить эту настройку экземпляра.</string>
-    <string name="instance_shortcut_not_supported">Ваш лаунчер главного экрана не поддерживает закреплённые ярлыки.</string>
-    <string name="instance_shortcut_missing">Этот экземпляр Minecraft больше недоступен.</string>
-    <string name="custom_flat_world_subtitle">Создайте мир со своим биомом и слоями блоков</string>
-    <string name="world_settings">Настройки мира</string>
-    <string name="world_settings_hint">Выберите основные настройки нового мира</string>
-    <string name="layers_title">Слои</string>
-    <string name="add_layer_compact">Добавить слой</string>
-    <string name="no_layers_title">Слоёв пока нет</string>
-    <string name="no_layers_hint">Добавьте хотя бы один слой блоков, чтобы создать мир</string>
-    <string name="reorder_layer">Изменить порядок слоя</string>
-    <string name="delete_layer">Удалить слой</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Сканировать</string>
-    <string name="scan_downloads_scanning">Сканирование…</string>
-    <string name="scan_downloads_none_found">В папке «Загрузки» не найдено модов .levipack или .so</string>
-    <string name="scan_downloads_failed">Не удалось просканировать папку «Загрузки»</string>
-    <string name="scan_downloads_permission_denied">Для сканирования папки «Загрузки» нужен доступ к хранилищу</string>
-    <string name="scan_downloads_results_title">Моды в папке «Загрузки»</string>
-    <string name="scan_downloads_results_subtitle">Выберите мод для добавления. Сканирование проверяет только основную папку «Загрузки».</string>
-    <string name="scan_downloads_add">Добавить</string>
-    <string name="scan_downloads_adding">Добавление…</string>
-    <string name="scan_downloads_added">Добавлено</string>
-    <string name="scan_downloads_added_message">%1$s добавлен</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Нативная библиотека</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Внешние моды</string>
-    <string name="external_mods_subtitle">Моды сообщества для Minecraft %1$s</string>
-    <string name="external_mods_no_version">Выберите версию Minecraft перед установкой модов</string>
-    <string name="external_mods_search_hint">Поиск модов, авторов или версий…</string>
-    <string name="external_mods_compatible_only">Только совместимые</string>
-    <string name="external_mods_all_versions">Все версии Minecraft</string>
-    <string name="external_mods_sort_newest">Сначала новые</string>
-    <string name="external_mods_sort_name">Название А–Я</string>
-    <string name="external_mods_empty">Нет модов, соответствующих этим фильтрам</string>
-    <string name="external_mods_load_failed">Не удалось обновить каталог. Показана сохранённая копия.</string>
-    <string name="external_mods_refresh">Обновить каталог</string>
-    <string name="external_mods_refreshed">Каталог обновлён</string>
-    <string name="external_mods_join_discord">Присоединиться к Discord сообщества</string>
-    <string name="external_mods_discord_open_failed">Нет приложения, которое может открыть приглашение Discord</string>
-    <string name="external_mods_download">Загрузка %1$s</string>
-    <string name="external_mods_importing">Импорт мода…</string>
-    <string name="external_mods_installed">%1$s установлен</string>
-    <string name="external_mods_install_failed">Не удалось установить %1$s: %2$s</string>
-    <string name="external_mods_open_failed">Нет браузера, который может открыть эту загрузку</string>
-    <string name="external_mods_direct_download">Прямая загрузка</string>
-    <string name="external_mods_ad_download">Загрузка с рекламой</string>
-    <string name="external_mods_external_link">Внешняя ссылка</string>
-    <string name="external_mods_open_link">Открыть ссылку</string>
-    <string name="external_mods_external_dialog_title">Внешняя загрузка</string>
-    <string name="external_mods_ad_dialog_title">Загрузка с рекламой</string>
-    <string name="external_mods_external_dialog_message">%1$s использует страницу загрузки вне LeviLauncher.\n\n1. Нажмите «Открыть ссылку» и скачайте файл .levipack или .so.\n2. Вернитесь в LeviLauncher и откройте «Моды».\n3. Нажмите «Сканировать».\n4. Нажмите «Добавить» рядом с модом, который хотите импортировать.\n\nСканирование проверяет только основную папку «Загрузки». Переместите файл туда, если браузер сохранил его в другом месте.</string>
-    <string name="external_mods_ad_dialog_message">%1$s использует страницу загрузки с рекламой, выбранную разработчиком. LeviLauncher не контролирует эту страницу или размещённую на ней рекламу.\n\n1. Нажмите «Открыть ссылку» и скачайте файл .levipack или .so.\n2. Вернитесь в LeviLauncher и откройте «Моды».\n3. Нажмите «Сканировать».\n4. Нажмите «Добавить» рядом с модом, который хотите импортировать.\n\nСканирование проверяет только основную папку «Загрузки». Скачивайте только файл мода; не устанавливайте посторонние приложения и не разрешайте уведомления.</string>
-    <string name="external_mods_by_author">от %1$s</string>
-    <string name="external_mods_version">Мод %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Обновить</string>
-    <string name="external_mods_installed_button">Установлено</string>
-    <string name="external_mods_incompatible">Несовместимо</string>
-    <string name="foreground_service">Служба переднего плана</string>
-    <string name="foreground_service_desc">Оставляет Minecraft запущенным при переключении между приложениями: не даёт Bedrock приостановить активный сеанс и поддерживает активность процесса, процессора и Wi-Fi.</string>
-    <string name="foreground_service_warning">Примечание: телефон может нагреваться быстрее, а расход батареи может увеличиться.</string>
-    <string name="foreground_service_channel">Защита Minecraft в фоновом режиме</string>
-    <string name="foreground_service_notification_title">Minecraft поддерживается активным</string>
-    <string name="foreground_service_notification_text">Фоновый режим Minecraft активен. Процессор и доступ к сети остаются доступными для текущего сеанса.</string>
-    <string name="mod_menu_compact">Компактное меню модов</string>
-    <string name="mod_menu_compact_desc">Использовать уменьшенное меню с плотным списком модулей и компактными фильтрами</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Множитель чувствительности (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Горизонтальная скорость (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Вертикальная скорость (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Фильтр малых движений (0 = выкл.)</string>
-    <string name="hud_editor_drag_hint">Перетащите, чтобы переместить панель</string>
-    <string name="hud_editor_drag_description">Редактор HUD. Перетащите эту область, чтобы переместить панель.</string>
     <string name="mod_config_hotbar_item_icons">Использовать значки предметов с панели быстрого доступа</string>
     <string name="mod_config_hotbar_item_counts">Показывать количество предметов</string>
     <string name="mod_config_hotbar_slot_enabled">Показывать слот %1$d панели быстрого доступа</string>
     <string name="mod_config_hotbar_slot_size">Размер слота %1$d панели быстрого доступа (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Непрозрачность слота %1$d панели быстрого доступа</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Что нового</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Продолжить</string>
@@ -1099,6 +1116,7 @@
     <string name="mod_config_category_button">Кнопка</string>
     <string name="mod_config_visible_slots">Видимые слоты</string>
     <string name="mod_config_hotbar_slot_section">Слот панели быстрого доступа %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Выбрать</string>
     <string name="select_all">Выбрать все</string>
     <string name="selected">Выбрано</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Чтобы установить или обновить это приложение, пожалуйста выдайте разрешение на установку неизвестных приложений. Нажмите "Выдать" чтобы открыть настройки системы, выдайте разрешение для этого приложения, и вернитесь чтобы продолжить.</string>
 
     <string name="check_update">Проверить обновления</string>
-    <string name="version_prefix">Версия:</string>
+    <string name="version_prefix">Версия :</string>
     <string name="unknown_error">Неизвестная ошибка</string>
     <string name="preloader_sigs_title">Данные среды выполнения</string>
     <string name="preloader_sigs_last_update">Последнее обновление: %1$s</string>
@@ -455,7 +455,7 @@
     <string name="invalid_license_detected_toast">Обнаружена нелицензионная версия Minecraft. Убедитесь, что Minecraft установлен из Google Play Маркета</string>
 
     <string name="full_mods_title">Моды</string>
-    <string name="total_mods">Всего модов:</string>
+    <string name="total_mods">Всего модов: </string>
     <string name="enabled_mods">Включено:</string>
     <string name="add_mod">Добавить мод</string>
     <string name="scan_downloads">Сканировать</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Bu uygulamayı yüklemek veya güncellemek için bilinmeyen uygulamaların yüklenmesine izin verin. "İzin Ver"e tıklayarak sistem ayarlarını açın, bu uygulama için izni etkinleştirin ve devam etmek için geri dönün.</string>
 
     <string name="check_update">Güncellemeleri Kontrol Et</string>
-    <string name="version_prefix">Sürüm:</string>
+    <string name="version_prefix">Sürüm: </string>
     <string name="unknown_error">Bilinmeyen hata</string>
     <string name="preloader_sigs_title">Çalışma zamanı verileri</string>
     <string name="preloader_sigs_last_update">Son güncelleme: %1$s</string>
@@ -452,7 +452,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="genuine_badge_label">Lisans doğrulanmadı</string>
     <string name="invalid_license_detected_toast">Orijinal olmayan Minecraft algılandı. Minecraft\'ın Google Play Store\'dan olduğundan emin olun</string>
 
-    <string name="full_mods_title">Modlar</string>
+    <string name="full_mods_title">Modlar </string>
     <string name="total_mods">Toplam Mod:</string>
     <string name="enabled_mods">Etkin:</string>
     <string name="add_mod">Mod Ekle</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,3 +1,11 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -68,6 +76,7 @@
     <string name="files_processed">%d mod dosyası başarıyla işlendi</string>
     <string name="user_cancelled">İçe aktarma kullanıcı tarafından iptal edildi</string>
 
+
     <string name="exit">Çıkış</string>
 
     <string name="overlay_permission_message">Lütfen katman iznini verin</string>
@@ -102,11 +111,12 @@
     <string name="settings_tab_migration">Taşıma</string>
     <string name="settings_theme_desc">Uygulama temasını seçin</string>
 
+
     <string name="unknown_sources_permission_title">Yükleme İzni</string>
     <string name="unknown_sources_permission_message">Bu uygulamayı yüklemek veya güncellemek için bilinmeyen uygulamaların yüklenmesine izin verin. "İzin Ver"e tıklayarak sistem ayarlarını açın, bu uygulama için izni etkinleştirin ve devam etmek için geri dönün.</string>
 
     <string name="check_update">Güncellemeleri Kontrol Et</string>
-    <string name="version_prefix">Sürüm: </string>
+    <string name="version_prefix">Sürüm:</string>
     <string name="unknown_error">Bilinmeyen hata</string>
     <string name="preloader_sigs_title">Çalışma zamanı verileri</string>
     <string name="preloader_sigs_last_update">Son güncelleme: %1$s</string>
@@ -130,6 +140,9 @@
     <string name="dialog_message_disable_version_isolation">Sürüm yalıtımı etkinken yüklü bir sürümü başlatmaya çalışıyorsunuz. Devam etmek için sürüm yalıtımını devre dışı bırakın.</string>
     <string name="dialog_positive_disable">Devre Dışı Bırak</string>
     <string name="dialog_positive_ok">Tamam</string>
+    <string name="delete_account_title">Hesabı Sil</string>
+    <string name="delete_account_confirm">Bu hesabı silmek istediğinizden emin misiniz?</string>
+
 
     <string name="new_version_found">Yeni sürüm bulundu: %1$s</string>
     <string name="update_question">En son sürümü indirip yüklemek istiyor musunuz?</string>
@@ -157,7 +170,7 @@
     <string name="repair_preparing">Hazırlanıyor…</string>
     <string name="repair_processing">Kütüphaneler çıkarılıyor…</string>
     <string name="repair_finalizing">Onarım tamamlanıyor…</string>
-
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Depolama Taşıması Gerekli</string>
     <string name="storage_migration_message">LeviLauncher, devam etmeden önce verileri games/org.levimc konumundan %1$s konumuna taşımalıdır.
 
@@ -202,21 +215,21 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="shared_storage_layout_mode_legacy">Orijinal dahili/harici dizinler</string>
     <string name="shared_storage_layout_status">Mevcut mod: %1$s\nDahili: %2$s\nHarici: %3$s</string>
     <string name="shared_storage_layout_changed">Depolama dizini seçimi güncellendi. Değişikliğin tam olarak uygulanması için Minecraft\'ı yeniden başlatın ve içerik yönetimini yeniden açın.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Tema Modu</string>
     <string name="theme_follow_system">Sistemi Takip Et</string>
     <string name="theme_light">Açık Mod</string>
     <string name="theme_dark">Koyu Mod</string>
 
     <string name="error_no_browser">Kullanılabilir tarayıcı yok</string>
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher Lisans Sözleşmesi</string>
     <string name="eula_message"><b>LeviLauncher\'a Hoş Geldiniz</b>\n\nBu yazılımı kullanarak aşağıdakileri kabul etmiş olursunuz:\n\n• Bu <b>resmi olmayan</b> bir Minecraft başlatıcısıdır\n• <b>Lisanslı</b> bir Minecraft kopyasına sahip olmanız gerekir\n• Her türlü korsan kullanım veya hile yasaktır\n• Modlar/kaynak paketleri kendi sorumluluğunuzda kullanılır\n• Mojang/Microsoft ile bağlantılı değildir\n\nKullanmaya devam etmek kabul anlamına gelir</string>
     <string name="eula_agree">Kabul Et</string>
     <string name="eula_exit">Reddet</string>
 
     <string name="allow_unknown_sources">Devam etmeden önce lütfen bilinmeyen kaynaklardan yüklemeye izin verin</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Sürümü Sil</string>
     <string name="dialog_message_delete_version">Bu özel sürümü silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.</string>
     <string name="dialog_positive_delete">Sil</string>
@@ -236,7 +249,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="version_isolation">Sürüm Yalıtımı</string>
     <string name="launch_vertically">Dikey Başlat</string>
     <string name="launch_vertically_desc">Oyunu dikey modda başlatmaya zorla</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Örnek Ayarları</string>
     <string name="instance_tab_general">Genel</string>
     <string name="instance_tab_launch_options">Başlatma Seçenekleri</string>
@@ -247,6 +260,16 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="instance_clear_icon">Temizle</string>
     <string name="instance_icon_hint">Sürüm klasörü altında LargeLogo.png olarak kaydedilecek. Değiştirmek için simgeye tıklayın.</string>
     <string name="instance_isolation_desc">Bu örnek için oyun verilerini yalıt. Diğer örnekler etkilenmez.</string>
+    <string name="instance_shortcut_title">Ana Ekran Kısayolu</string>
+    <string name="instance_shortcut_desc">Ad ve simge değişiklikleri otomatik olarak kaydedilir. Ana ekran kısayolunu oluşturmak veya güncellemek için Kısayol Ekle’ye dokunun.</string>
+    <string name="instance_shortcut_name">Kısayol Adı</string>
+    <string name="instance_shortcut_icon">Kısayol Simgesi</string>
+    <string name="instance_shortcut_choose_icon">Simge Seç</string>
+    <string name="instance_shortcut_default_icon">Varsayılanı Kullan</string>
+    <string name="instance_shortcut_add_button">Kısayol Ekle</string>
+    <string name="instance_settings_auto_save_failed">Bu örnek ayarı kaydedilemedi.</string>
+    <string name="instance_shortcut_not_supported">Ana ekran başlatıcınız sabitlenmiş kısayolları desteklemiyor.</string>
+    <string name="instance_shortcut_missing">Bu Minecraft örneği artık kullanılamıyor.</string>
     <string name="instance_danger_zone">Tehlikeli Bölge</string>
     <string name="instance_danger_zone_desc">Bu işlemler örnek kaydını veya yerel dosyaları etkiler. Devam etmeden önce iki kez kontrol edin.</string>
     <string name="instance_delete_desc">Bu örneği dünyalar, yapılandırmalar ve yüklü içerikler dahil olmak üzere cihazınızdan kalıcı olarak siler.</string>
@@ -284,6 +307,8 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="instance_restore_failed_message">Yedek geri yüklenemedi:\n%1$s</string>
 
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">Dil (Language)</string>
     <string name="english">İngilizce (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -377,6 +402,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="edit_world">Dünyayı Düzenle</string>
     <string name="edit">Düzenle</string>
     <string name="save">Kaydet</string>
+    <string name="reset">Sıfırla</string>
     <string name="saved_to_gallery">Galeriye kaydedildi</string>
     <string name="level_dat_not_found">level.dat bulunamadı</string>
     <string name="no_editable_properties">Düzenlenebilir özellik bulunamadı</string>
@@ -401,6 +427,20 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="add_at_least_one_layer">En az bir katman ekleyin</string>
     <string name="world_created_successfully">Dünya başarıyla oluşturuldu</string>
     <string name="failed_to_create_world">Dünya oluşturulamadı</string>
+    <string name="custom_flat_world_subtitle">Kendi biyomunuz ve blok katmanlarınızla bir dünya oluşturun</string>
+    <string name="world_settings">Dünya Ayarları</string>
+    <string name="world_settings_hint">Yeni dünya için temel ayarları seçin</string>
+    <string name="layers_title">Katmanlar</string>
+    <string name="add_layer_compact">Katman Ekle</string>
+    <string name="no_layers_title">Henüz katman yok</string>
+    <string name="no_layers_hint">Dünyayı oluşturmak için en az bir blok katmanı ekleyin</string>
+    <string name="reorder_layer">Katmanı yeniden sırala</string>
+    <string name="delete_layer">Katmanı sil</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d katman • alt → üst</item>
+        <item quantity="other">%1$d katman • alt → üst</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Play Store Sürümü Gerekli</string>
@@ -412,10 +452,57 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="genuine_badge_label">Lisans doğrulanmadı</string>
     <string name="invalid_license_detected_toast">Orijinal olmayan Minecraft algılandı. Minecraft\'ın Google Play Store\'dan olduğundan emin olun</string>
 
-    <string name="full_mods_title">Modlar </string>
+    <string name="full_mods_title">Modlar</string>
     <string name="total_mods">Toplam Mod:</string>
     <string name="enabled_mods">Etkin:</string>
     <string name="add_mod">Mod Ekle</string>
+    <string name="scan_downloads">Tara</string>
+    <string name="scan_downloads_scanning">Taranıyor…</string>
+    <string name="scan_downloads_none_found">İndirilenler’de .levipack veya .so mod bulunamadı</string>
+    <string name="scan_downloads_failed">İndirilenler taranamadı</string>
+    <string name="scan_downloads_permission_denied">İndirilenler’i taramak için depolama erişimi gerekiyor</string>
+    <string name="scan_downloads_results_title">İndirilenler’deki Modlar</string>
+    <string name="scan_downloads_results_subtitle">Eklemek için bir mod seçin. Tarama yalnızca ana İndirilenler klasörünü kontrol eder.</string>
+    <string name="scan_downloads_add">Ekle</string>
+    <string name="scan_downloads_adding">Ekleniyor…</string>
+    <string name="scan_downloads_added">Eklendi</string>
+    <string name="scan_downloads_added_message">%1$s eklendi</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Yerel kitaplık</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Harici Modlar</string>
+    <string name="external_mods_subtitle">Minecraft %1$s için topluluk modları</string>
+    <string name="external_mods_no_version">Mod yüklemeden önce bir Minecraft sürümü seçin</string>
+    <string name="external_mods_search_hint">Mod, geliştirici veya sürüm ara…</string>
+    <string name="external_mods_compatible_only">Yalnızca uyumlu</string>
+    <string name="external_mods_all_versions">Tüm Minecraft sürümleri</string>
+    <string name="external_mods_sort_newest">En yeni</string>
+    <string name="external_mods_sort_name">Ad A–Z</string>
+    <string name="external_mods_empty">Bu filtrelerle eşleşen mod yok</string>
+    <string name="external_mods_load_failed">Katalog yenilenemedi. Kaydedilmiş kopya gösteriliyor.</string>
+    <string name="external_mods_refresh">Kataloğu yenile</string>
+    <string name="external_mods_refreshed">Katalog yenilendi</string>
+    <string name="external_mods_join_discord">Topluluk Discord’una Katıl</string>
+    <string name="external_mods_discord_open_failed">Discord davetini açabilecek bir uygulama yok</string>
+    <string name="external_mods_download">%1$s indiriliyor</string>
+    <string name="external_mods_importing">Mod içe aktarılıyor…</string>
+    <string name="external_mods_installed">%1$s yüklendi</string>
+    <string name="external_mods_install_failed">%1$s yüklenemedi: %2$s</string>
+    <string name="external_mods_open_failed">Bu indirmeyi açabilecek bir tarayıcı yok</string>
+    <string name="external_mods_direct_download">Doğrudan indirme</string>
+    <string name="external_mods_ad_download">Reklamlı indirme</string>
+    <string name="external_mods_external_link">Harici bağlantı</string>
+    <string name="external_mods_open_link">Bağlantıyı Aç</string>
+    <string name="external_mods_external_dialog_title">Harici İndirme</string>
+    <string name="external_mods_ad_dialog_title">Reklam Destekli İndirme</string>
+    <string name="external_mods_external_dialog_message">%1$s, LeviLauncher dışında bir indirme sayfası kullanıyor.\n\n1. Bağlantıyı Aç’a dokunun ve .levipack veya .so dosyasını indirin.\n2. LeviLauncher’a dönün ve Modlar’ı açın.\n3. Tara’ya dokunun.\n4. İçe aktarmak istediğiniz modun yanındaki Ekle’ye dokunun.\n\nTarama yalnızca ana İndirilenler klasörünü kontrol eder. Tarayıcınız dosyayı başka bir yere kaydettiyse buraya taşıyın.</string>
+    <string name="external_mods_ad_dialog_message">%1$s, geliştiricisi tarafından seçilen reklam destekli bir indirme sayfası kullanıyor. LeviLauncher bu sayfayı veya reklamlarını kontrol etmez.\n\n1. Bağlantıyı Aç’a dokunun ve .levipack veya .so dosyasını indirin.\n2. LeviLauncher’a dönün ve Modlar’ı açın.\n3. Tara’ya dokunun.\n4. İçe aktarmak istediğiniz modun yanındaki Ekle’ye dokunun.\n\nTarama yalnızca ana İndirilenler klasörünü kontrol eder. Yalnızca mod dosyasını indirin; ilgisiz uygulamalar yüklemeyin veya bildirimlere izin vermeyin.</string>
+    <string name="external_mods_by_author">%1$s tarafından</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Güncelle</string>
+    <string name="external_mods_installed_button">Yüklendi</string>
+    <string name="external_mods_incompatible">Uyumsuz</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">Mod Ayrıntıları</string>
@@ -463,7 +550,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="mod_config_error_maximum">%1$s en fazla %2$s olmalıdır</string>
     <string name="mod_config_error_boolean">%1$s açık veya kapalı olmalıdır</string>
     <string name="mod_config_error_string">%1$s metin olmalıdır</string>
-
+    <!-- Mod Configuration -->
     <plurals name="mod_config_files_count">
         <item quantity="one">%d düzenlenebilir yapılandırma</item>
         <item quantity="other">%d düzenlenebilir yapılandırma</item>
@@ -506,13 +593,45 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="accounts_active_privilege">Oturum açıldı</string>
 
     <string name="ms_login_title">Microsoft Girişi</string>
+    <string name="ms_login_header_subtitle">Minecraft’ta güvenli şekilde oturum açın</string>
     <string name="ms_login_starting">Microsoft girişi başlatılıyor…</string>
     <string name="ms_login_exchanging">Jeton değiştiriliyor…</string>
     <string name="ms_login_auth_xbox_device">Xbox cihazı doğrulanıyor…</string>
     <string name="ms_login_fetch_minecraft_identity">Minecraft kimliği alınıyor…</string>
+    <string name="ms_login_retrying">Bağlantı kesildi. Güvenli şekilde yeniden deneniyor…</string>
     <string name="ms_login_success">%1$s olarak oturum açıldı</string>
     <string name="ms_login_failed">Microsoft girişi başarısız</string>
     <string name="ms_login_failed_detail">Giriş başarısız: %1$s</string>
+    <string name="ms_choose_login_method">Minecraft’ta oturum aç</string>
+    <string name="ms_choose_login_method_desc">Tarayıcı tabanlı cihaz kodu akışını seçin veya gömülü Microsoft sayfasıyla devam edin.</string>
+    <string name="ms_device_code_login">Tarayıcıyla devam et</string>
+    <string name="ms_device_code_option_title">Cihaz Kodu (Önerilen)</string>
+    <string name="ms_device_code_login_desc">Cihaz kodu önceden doldurulmuş özel bir tarayıcı oturumu açın.</string>
+    <string name="ms_webview_login">Gömülü oturum açmayı aç</string>
+    <string name="ms_webview_option_title">Gömülü WebView</string>
+    <string name="ms_webview_login_desc">LeviLauncher’dan çıkmadan oturum açın. Tarayıcı akışı kullanılamadığında bunu kullanın.</string>
+    <string name="ms_device_code_title">Cihaz Koduyla Oturum Aç</string>
+    <string name="ms_device_code_instructions">Microsoft’un cihaz oturum açma sayfasını açın, bu kodu girin ve erişimi onaylayın. LeviLauncher otomatik olarak tamamlayacaktır.</string>
+    <string name="ms_device_code_label">Microsoft cihaz kodu</string>
+    <string name="ms_device_code_requesting">Güvenli kod isteniyor…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Tarayıcıda tamamlamanız bekleniyor…</string>
+    <string name="ms_device_code_checking">Microsoft oturum açma sonucu kontrol ediliyor…</string>
+    <string name="ms_device_code_reconnecting">Bağlantı değişti. Otomatik olarak yeniden deneniyor…</string>
+    <string name="ms_device_code_authorized">Microsoft oturum açmayı onayladı. Tamamlanıyor…</string>
+    <string name="ms_device_code_browser_opened">Tarayıcınızda yeni Microsoft oturum açmasını tamamlayın, ardından buraya dönün.</string>
+    <string name="ms_device_code_expires">Kod %1$d:%2$02d içinde sona eriyor</string>
+    <string name="ms_device_code_copy">Kodu Kopyala</string>
+    <string name="ms_device_code_copied">Kod kopyalandı</string>
+    <string name="ms_device_code_open_browser">Microsoft oturum açmayı aç</string>
+    <string name="ms_device_code_step_title">Oturum açmayı tarayıcınızda tamamlayın</string>
+    <string name="ms_device_code_browser_note">LeviLauncher varsayılan tarayıcınızı özel bir oturumda açar, kodu otomatik doldurur ve yeni bir Microsoft oturum açması ister.</string>
+    <string name="ms_choose_other_method">Diğer yöntem</string>
+    <string name="ms_no_browser">Bu cihazda kullanılabilir tarayıcı yok.</string>
+    <string name="ms_default_browser_no_private_mode">Varsayılan tarayıcınız özel oturum açmayı desteklemiyor. Güncelleyin veya WebView oturum açmayı kullanın.</string>
+    <string name="ms_login_ssl_failed">Güvenli Microsoft oturum açma sayfası doğrulanamadı.</string>
+    <string name="ms_login_state_failed">Microsoft oturum açma yanıtı doğrulanamadı. Oturum açmayı yeniden başlatın.</string>
+    <string name="ms_login_missing_code">Microsoft bir oturum açma kodu döndürmedi. Oturum açmayı yeniden başlatın veya Cihaz Kodu ile oturum açmayı kullanın.</string>
 
     <string name="ms_set_active">Etkin Olarak Ayarla</string>
     <string name="ms_delete">Sil</string>
@@ -525,10 +644,14 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="go_to_accounts">Hesaplar</string>
     <string name="disable_launcher_login_and_continue">Kapat</string>
 
+    <string name="ms_feature_disabled_title">Özellik Devre Dışı</string>
+    <string name="ms_feature_disabled_desc">Microsoft hesaplarını yönetmek için Ayarlar’da “LeviLauncher ile Minecraft’ta oturum aç” seçeneğini etkinleştirin.</string>
+    <string name="ms_activated">Etkinleştirildi</string>
+
     <!-- Popup labels -->
     <string name="label_current_account">Mevcut Hesap</string>
     <string name="label_other_accounts">Diğer Hesaplar</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">Uygulama çöktü</string>
     <string name="crash_upload">Çökme raporu yükleme</string>
     <string name="crash_details_title">Çökme ayrıntıları</string>
@@ -547,9 +670,15 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="dialog_message_exit_app">Çıkmak istediğinizden emin misiniz?</string>
     <string name="dialog_positive_exit">Çık</string>
     <string name="show_logcat_overlay">Logcat katmanı</string>
+    <string name="foreground_service">Ön plan hizmeti</string>
+    <string name="foreground_service_desc">Uygulamalar arasında geçiş yaparken Bedrock’un etkin oturumu askıya almasını önleyerek ve işlem, CPU ile Wi-Fi’yi etkin tutarak Minecraft’ın çalışmaya devam etmesini sağlar.</string>
+    <string name="foreground_service_warning">Not: Telefonunuzun daha hızlı ısınmasına ve pil kullanımının artmasına neden olabilir.</string>
+    <string name="foreground_service_channel">Minecraft arka plan koruması</string>
+    <string name="foreground_service_notification_title">Minecraft etkin tutuluyor</string>
+    <string name="foreground_service_notification_text">Minecraft arka plan modu etkin. Geçerli oturum için CPU ve ağ erişimi kullanılabilir tutuluyor.</string>
     <string name="logcat_live">Logcat: <b>canlı</b></string>
     <string name="logcat_paused">Logcat: duraklatıldı</string>
-    <!-- Logcat Overlay -->
+    <!-- Logcat Overlay i18n -->
     <string name="logcat_filter_hint">Anahtar kelime filtresi</string>
     <string name="logcat_blacklist_hint">Kara liste (virgülle ayrılmış)</string>
     <string name="logcat_filter_clear">Filtreleri temizle</string>
@@ -570,8 +699,8 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="inbuilt_mod_removed">%s modlardan kaldırıldı</string>
     <string name="add">Ekle</string>
     <string name="remove">Kaldır</string>
-
-    <!-- Inbuilt Mod Names -->
+    
+    <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">Hızlı Bırak</string>
     <string name="inbuilt_mod_quick_drop_desc">Eşyaları hızlıca bırak</string>
     <string name="inbuilt_mod_camera">Hızlı Bakış Açısı</string>
@@ -599,12 +728,20 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="virtual_cursor_enabled">İmleç etkinleştirildi</string>
     <string name="virtual_cursor_disabled">İmleç devre dışı bırakıldı</string>
     <string name="cursor_sensitivity_label">İmleç Hassasiyeti:</string>
+    <string name="inbuilt_mod_gyro">Jiroskop</string>
+    <string name="inbuilt_mod_gyro_desc">Kamera dönüşünü kontrol etmek için cihaz jiroskobunu kullanın</string>
+    <string name="inbuilt_mod_pojav_controls">Pojav Kontrolleri</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Minecraft dokunmatik kontrollerini tamamen özelleştirilebilir Pojav tarzı kontrollerle değiştirin</string>
+    <string name="inbuilt_mod_more_buttons">Daha Fazla Düğme</string>
+    <string name="inbuilt_mod_more_buttons_desc">Tek tuş eşlemeleri ve SVG simgeleriyle özel ekran düğmeleri oluşturun</string>
     <string name="inbuilt_badge">YERLEŞİK</string>
     <string name="autosprint_keybind_label">Otomatik Koş Tuşu:</string>
     <string name="autosprint_keybind_press">Herhangi bir tuşa basın…</string>
     <string name="configure">Yapılandır</string>
     <string name="overlay_button_size">Katman Düğmesi Boyutu</string>
     <string name="overlay_button_opacity">Katman Düğmesi Opaklığı</string>
+    <string name="overlay_button_size_value">Boyut: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Opaklık: %1$d%%</string>
     <string name="overlay_button_lock">Konumu Kilitle</string>
     <string name="overlay_button_lock_desc">Sürüklemeyi ve yanlışlıkla etkinleştirmeyi engelle</string>
     <string name="settings">Ayarlar</string>
@@ -626,13 +763,33 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <!-- Mod Menu -->
     <string name="mod_menu">Mod Menüsü</string>
     <string name="mod_menu_modules">Modüller</string>
+    <string name="mod_menu_favorites">Favoriler</string>
+    <string name="mod_menu_favorite">Favorilere ekle</string>
+    <string name="mod_menu_unfavorite">Favorilerden kaldır</string>
+    <string name="mod_menu_hud_editor">HUD Düzenleyici</string>
+    <string name="mod_menu_filter_enabled">Etkin</string>
+    <string name="mod_menu_filter_inbuilt">Yerleşik</string>
+    <string name="mod_menu_filter_external">Harici</string>
     <string name="mod_menu_search_hint">Mod ara…</string>
     <string name="mod_menu_no_mods">Mod eklenmedi</string>
+    <string name="mod_menu_no_favorites">Henüz favori mod yok</string>
+    <string name="mod_menu_no_matches">Eşleşen mod yok</string>
+    <string name="mod_menu_group_inbuilt">Yerleşik Özellikler</string>
+    <string name="mod_menu_group_external_ungrouped">Gruplandırılmamış Harici Modlar</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Genel Ayarlar</string>
+    <string name="mod_menu_appearance">Görünüm</string>
+    <string name="mod_menu_pause_menu_only">Yalnızca Duraklatma Menüsü</string>
+    <string name="mod_menu_pause_menu_only_desc">Mod menüsünü yalnızca duraklatma ekranında göster</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Ayarlar yakında geliyor</string>
     <string name="mod_menu_notifications">Bildirimler</string>
     <string name="mod_menu_notifications_desc">Modlar etkinleştirildiğinde bildirim göster</string>
     <string name="mod_menu_opacity">Mod Menüsü Opaklığı</string>
     <string name="mod_menu_button_opacity">Mod Menüsü Düğmesi Opaklığı</string>
+    <string name="mod_menu_compact">Kompakt Mod Menüsü</string>
+    <string name="mod_menu_compact_desc">Yoğun modül listesi ve kompakt filtrelerle daha küçük bir menü kullanın</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Mod Menüsü etkinleştirildi</string>
     <string name="mod_menu_disabled">Mod Menüsü devre dışı bırakıldı</string>
@@ -641,6 +798,35 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="mod_status_enabled">Etkin</string>
     <string name="mod_status_disabled">Devre Dışı</string>
     <string name="mod_notification_enabled">%s etkinleştirildi</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Yer paylaşımı düğmesi boyutu (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Yer paylaşımı opaklığı (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Her Yerde Göster</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">İmleç hassasiyeti (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Yakınlaştırma seviyesi (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Otomatik koşu tuş ataması</string>
+    <string name="mod_config_zoom_keybind">Yakınlaştırma tuş ataması</string>
+    <string name="mod_config_zoom_transition">Geçiş Süresi (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Hassasiyet Çarpanı (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Yatay Hız (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Dikey Hız (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Küçük Hareket Filtresi (0 = Kapalı)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Yatay Hassasiyet (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Dikey Hassasiyet (%)</string>
+    <string name="mod_config_gyro_invert_x">Yatay Ekseni Ters Çevir</string>
+    <string name="mod_config_gyro_invert_y">Dikey Ekseni Ters Çevir</string>
+    <string name="mod_config_gyro_deadzone">Ölü Bölge</string>
+    <string name="mod_config_press_any_key">Atamak için herhangi bir tuşa basın...</string>
+    <string name="mod_config_key_unknown">BİLİNMİYOR</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Paneli taşımak için sürükleyin</string>
+    <string name="hud_editor_drag_description">HUD Düzenleyici. Paneli taşımak için bu alanı sürükleyin.</string>
 
     <!-- Options Editor -->
     <string name="edit_options">Seçenekleri Düzenle</string>
@@ -767,7 +953,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
         <item>CurseForge, topluluk içeriklerine doğrudan göz atmanızı ve indirmenizi sağlar.</item>
         <item>Minecraft özelliklerini ve performansını genişletmek veya geliştirmek için mod içe aktarın.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Tema Rengi</string>
     <string name="theme_color_desc">Uygulamanın birincil vurgu rengi</string>
     <string name="preset_colors">HAZIR RENKLER</string>
@@ -785,95 +971,8 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
 
     <string name="unsupported_version_title">Desteklenmeyen Sürüm</string>
     <string name="unsupported_version_msg">Bu başlatıcı 1.21.80\'den eski Minecraft sürümlerini desteklemiyor.</string>
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Favoriler</string>
-    <string name="mod_menu_favorite">Favorilere ekle</string>
-    <string name="mod_menu_unfavorite">Favorilerden kaldır</string>
-    <string name="mod_menu_hud_editor">HUD Düzenleyici</string>
-    <string name="mod_menu_filter_enabled">Etkin</string>
-    <string name="mod_menu_filter_inbuilt">Yerleşik</string>
-    <string name="mod_menu_filter_external">Harici</string>
-    <string name="mod_menu_no_favorites">Henüz favori mod yok</string>
-    <string name="mod_menu_no_matches">Eşleşen mod yok</string>
-    <string name="mod_menu_group_inbuilt">Yerleşik Özellikler</string>
-    <string name="mod_menu_group_external_ungrouped">Gruplandırılmamış Harici Modlar</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Genel Ayarlar</string>
-    <string name="mod_menu_appearance">Görünüm</string>
-    <string name="mod_menu_pause_menu_only">Yalnızca Duraklatma Menüsü</string>
-    <string name="mod_menu_pause_menu_only_desc">Mod menüsünü yalnızca duraklatma ekranında göster</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Yer paylaşımı düğmesi boyutu (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Yer paylaşımı opaklığı (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">İmleç hassasiyeti (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Yakınlaştırma seviyesi (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Otomatik koşu tuş ataması</string>
-    <string name="mod_config_zoom_keybind">Yakınlaştırma tuş ataması</string>
-    <string name="mod_config_press_any_key">Atamak için herhangi bir tuşa basın...</string>
-    <string name="mod_config_key_unknown">BİLİNMİYOR</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Boyut: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Opaklık: %1$d%%</string>
-    <string name="reset">Sıfırla</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">Hesabı Sil</string>
-    <string name="delete_account_confirm">Bu hesabı silmek istediğinizden emin misiniz?</string>
-    <string name="ms_login_header_subtitle">Minecraft’ta güvenli şekilde oturum açın</string>
-    <string name="ms_login_retrying">Bağlantı kesildi. Güvenli şekilde yeniden deneniyor…</string>
-    <string name="ms_choose_login_method">Minecraft’ta oturum aç</string>
-    <string name="ms_choose_login_method_desc">Tarayıcı tabanlı cihaz kodu akışını seçin veya gömülü Microsoft sayfasıyla devam edin.</string>
-    <string name="ms_device_code_login">Tarayıcıyla devam et</string>
-    <string name="ms_device_code_option_title">Cihaz Kodu (Önerilen)</string>
-    <string name="ms_device_code_login_desc">Cihaz kodu önceden doldurulmuş özel bir tarayıcı oturumu açın.</string>
-    <string name="ms_webview_login">Gömülü oturum açmayı aç</string>
-    <string name="ms_webview_option_title">Gömülü WebView</string>
-    <string name="ms_webview_login_desc">LeviLauncher’dan çıkmadan oturum açın. Tarayıcı akışı kullanılamadığında bunu kullanın.</string>
-    <string name="ms_device_code_title">Cihaz Koduyla Oturum Aç</string>
-    <string name="ms_device_code_instructions">Microsoft’un cihaz oturum açma sayfasını açın, bu kodu girin ve erişimi onaylayın. LeviLauncher otomatik olarak tamamlayacaktır.</string>
-    <string name="ms_device_code_label">Microsoft cihaz kodu</string>
-    <string name="ms_device_code_requesting">Güvenli kod isteniyor…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Tarayıcıda tamamlamanız bekleniyor…</string>
-    <string name="ms_device_code_checking">Microsoft oturum açma sonucu kontrol ediliyor…</string>
-    <string name="ms_device_code_reconnecting">Bağlantı değişti. Otomatik olarak yeniden deneniyor…</string>
-    <string name="ms_device_code_authorized">Microsoft oturum açmayı onayladı. Tamamlanıyor…</string>
-    <string name="ms_device_code_browser_opened">Tarayıcınızda yeni Microsoft oturum açmasını tamamlayın, ardından buraya dönün.</string>
-    <string name="ms_device_code_expires">Kod %1$d:%2$02d içinde sona eriyor</string>
-    <string name="ms_device_code_copy">Kodu Kopyala</string>
-    <string name="ms_device_code_copied">Kod kopyalandı</string>
-    <string name="ms_device_code_open_browser">Microsoft oturum açmayı aç</string>
-    <string name="ms_device_code_step_title">Oturum açmayı tarayıcınızda tamamlayın</string>
-    <string name="ms_device_code_browser_note">LeviLauncher varsayılan tarayıcınızı özel bir oturumda açar, kodu otomatik doldurur ve yeni bir Microsoft oturum açması ister.</string>
-    <string name="ms_choose_other_method">Diğer yöntem</string>
-    <string name="ms_no_browser">Bu cihazda kullanılabilir tarayıcı yok.</string>
-    <string name="ms_default_browser_no_private_mode">Varsayılan tarayıcınız özel oturum açmayı desteklemiyor. Güncelleyin veya WebView oturum açmayı kullanın.</string>
-    <string name="ms_login_ssl_failed">Güvenli Microsoft oturum açma sayfası doğrulanamadı.</string>
-    <string name="ms_login_state_failed">Microsoft oturum açma yanıtı doğrulanamadı. Oturum açmayı yeniden başlatın.</string>
-    <string name="ms_login_missing_code">Microsoft bir oturum açma kodu döndürmedi. Oturum açmayı yeniden başlatın veya Cihaz Kodu ile oturum açmayı kullanın.</string>
-    <string name="ms_feature_disabled_title">Özellik Devre Dışı</string>
-    <string name="ms_feature_disabled_desc">Microsoft hesaplarını yönetmek için Ayarlar’da “LeviLauncher ile Minecraft’ta oturum aç” seçeneğini etkinleştirin.</string>
-    <string name="ms_activated">Etkinleştirildi</string>
-    <string name="inbuilt_mod_gyro">Jiroskop</string>
-    <string name="inbuilt_mod_gyro_desc">Kamera dönüşünü kontrol etmek için cihaz jiroskobunu kullanın</string>
-    <string name="inbuilt_mod_pojav_controls">Pojav Kontrolleri</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Minecraft dokunmatik kontrollerini tamamen özelleştirilebilir Pojav tarzı kontrollerle değiştirin</string>
-    <string name="inbuilt_mod_more_buttons">Daha Fazla Düğme</string>
-    <string name="inbuilt_mod_more_buttons_desc">Tek tuş eşlemeleri ve SVG simgeleriyle özel ekran düğmeleri oluşturun</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Her Yerde Göster</string>
-    <string name="mod_config_zoom_transition">Geçiş Süresi (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Yatay Hassasiyet (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Dikey Hassasiyet (%)</string>
-    <string name="mod_config_gyro_invert_x">Yatay Ekseni Ters Çevir</string>
-    <string name="mod_config_gyro_invert_y">Dikey Ekseni Ters Çevir</string>
-    <string name="mod_config_gyro_deadzone">Ölü Bölge</string>
+
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Kapat</string>
     <string name="previous">Önceki</string>
     <string name="next">İleri</string>
@@ -923,6 +1022,8 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="custom_color_hint">#RRGGBB veya R,G,B</string>
     <string name="screenshot_name_placeholder">Ekran Görüntüsü Adı</string>
     <string name="screenshot_date_placeholder">Tarih: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Her biri tam olarak bir klavye tuşuna eşlenen Minecraft tarzı ekran düğmeleri oluşturun. Düğmeler makro, tuş dizisi, otomatik tekrar veya otomatik tıklama çalıştırmaz.</string>
     <string name="more_buttons_add_button">Düğme Ekle</string>
     <string name="more_buttons_limit_reached">En fazla %1$d özel düğme sınırına ulaşıldı.</string>
@@ -980,99 +1081,17 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="more_buttons_no_svg_selected">SVG seçilmedi</string>
     <string name="more_buttons_default_name">Düğme</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Hızlı Erişim Yuvası</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Hızlı erişim yuvalarını seçmek için ayrı 1–9 düğmeleri ekler</string>
     <string name="hotbar_slot_content_description">Hızlı erişim yuvası %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Ana Ekran Kısayolu</string>
-    <string name="instance_shortcut_desc">Ad ve simge değişiklikleri otomatik olarak kaydedilir. Ana ekran kısayolunu oluşturmak veya güncellemek için Kısayol Ekle’ye dokunun.</string>
-    <string name="instance_shortcut_name">Kısayol Adı</string>
-    <string name="instance_shortcut_icon">Kısayol Simgesi</string>
-    <string name="instance_shortcut_choose_icon">Simge Seç</string>
-    <string name="instance_shortcut_default_icon">Varsayılanı Kullan</string>
-    <string name="instance_shortcut_add_button">Kısayol Ekle</string>
-    <string name="instance_settings_auto_save_failed">Bu örnek ayarı kaydedilemedi.</string>
-    <string name="instance_shortcut_not_supported">Ana ekran başlatıcınız sabitlenmiş kısayolları desteklemiyor.</string>
-    <string name="instance_shortcut_missing">Bu Minecraft örneği artık kullanılamıyor.</string>
-    <string name="custom_flat_world_subtitle">Kendi biyomunuz ve blok katmanlarınızla bir dünya oluşturun</string>
-    <string name="world_settings">Dünya Ayarları</string>
-    <string name="world_settings_hint">Yeni dünya için temel ayarları seçin</string>
-    <string name="layers_title">Katmanlar</string>
-    <string name="add_layer_compact">Katman Ekle</string>
-    <string name="no_layers_title">Henüz katman yok</string>
-    <string name="no_layers_hint">Dünyayı oluşturmak için en az bir blok katmanı ekleyin</string>
-    <string name="reorder_layer">Katmanı yeniden sırala</string>
-    <string name="delete_layer">Katmanı sil</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Tara</string>
-    <string name="scan_downloads_scanning">Taranıyor…</string>
-    <string name="scan_downloads_none_found">İndirilenler’de .levipack veya .so mod bulunamadı</string>
-    <string name="scan_downloads_failed">İndirilenler taranamadı</string>
-    <string name="scan_downloads_permission_denied">İndirilenler’i taramak için depolama erişimi gerekiyor</string>
-    <string name="scan_downloads_results_title">İndirilenler’deki Modlar</string>
-    <string name="scan_downloads_results_subtitle">Eklemek için bir mod seçin. Tarama yalnızca ana İndirilenler klasörünü kontrol eder.</string>
-    <string name="scan_downloads_add">Ekle</string>
-    <string name="scan_downloads_adding">Ekleniyor…</string>
-    <string name="scan_downloads_added">Eklendi</string>
-    <string name="scan_downloads_added_message">%1$s eklendi</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Yerel kitaplık</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Harici Modlar</string>
-    <string name="external_mods_subtitle">Minecraft %1$s için topluluk modları</string>
-    <string name="external_mods_no_version">Mod yüklemeden önce bir Minecraft sürümü seçin</string>
-    <string name="external_mods_search_hint">Mod, geliştirici veya sürüm ara…</string>
-    <string name="external_mods_compatible_only">Yalnızca uyumlu</string>
-    <string name="external_mods_all_versions">Tüm Minecraft sürümleri</string>
-    <string name="external_mods_sort_newest">En yeni</string>
-    <string name="external_mods_sort_name">Ad A–Z</string>
-    <string name="external_mods_empty">Bu filtrelerle eşleşen mod yok</string>
-    <string name="external_mods_load_failed">Katalog yenilenemedi. Kaydedilmiş kopya gösteriliyor.</string>
-    <string name="external_mods_refresh">Kataloğu yenile</string>
-    <string name="external_mods_refreshed">Katalog yenilendi</string>
-    <string name="external_mods_join_discord">Topluluk Discord’una Katıl</string>
-    <string name="external_mods_discord_open_failed">Discord davetini açabilecek bir uygulama yok</string>
-    <string name="external_mods_download">%1$s indiriliyor</string>
-    <string name="external_mods_importing">Mod içe aktarılıyor…</string>
-    <string name="external_mods_installed">%1$s yüklendi</string>
-    <string name="external_mods_install_failed">%1$s yüklenemedi: %2$s</string>
-    <string name="external_mods_open_failed">Bu indirmeyi açabilecek bir tarayıcı yok</string>
-    <string name="external_mods_direct_download">Doğrudan indirme</string>
-    <string name="external_mods_ad_download">Reklamlı indirme</string>
-    <string name="external_mods_external_link">Harici bağlantı</string>
-    <string name="external_mods_open_link">Bağlantıyı Aç</string>
-    <string name="external_mods_external_dialog_title">Harici İndirme</string>
-    <string name="external_mods_ad_dialog_title">Reklam Destekli İndirme</string>
-    <string name="external_mods_external_dialog_message">%1$s, LeviLauncher dışında bir indirme sayfası kullanıyor.\n\n1. Bağlantıyı Aç’a dokunun ve .levipack veya .so dosyasını indirin.\n2. LeviLauncher’a dönün ve Modlar’ı açın.\n3. Tara’ya dokunun.\n4. İçe aktarmak istediğiniz modun yanındaki Ekle’ye dokunun.\n\nTarama yalnızca ana İndirilenler klasörünü kontrol eder. Tarayıcınız dosyayı başka bir yere kaydettiyse buraya taşıyın.</string>
-    <string name="external_mods_ad_dialog_message">%1$s, geliştiricisi tarafından seçilen reklam destekli bir indirme sayfası kullanıyor. LeviLauncher bu sayfayı veya reklamlarını kontrol etmez.\n\n1. Bağlantıyı Aç’a dokunun ve .levipack veya .so dosyasını indirin.\n2. LeviLauncher’a dönün ve Modlar’ı açın.\n3. Tara’ya dokunun.\n4. İçe aktarmak istediğiniz modun yanındaki Ekle’ye dokunun.\n\nTarama yalnızca ana İndirilenler klasörünü kontrol eder. Yalnızca mod dosyasını indirin; ilgisiz uygulamalar yüklemeyin veya bildirimlere izin vermeyin.</string>
-    <string name="external_mods_by_author">%1$s tarafından</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Güncelle</string>
-    <string name="external_mods_installed_button">Yüklendi</string>
-    <string name="external_mods_incompatible">Uyumsuz</string>
-    <string name="foreground_service">Ön plan hizmeti</string>
-    <string name="foreground_service_desc">Uygulamalar arasında geçiş yaparken Bedrock’un etkin oturumu askıya almasını önleyerek ve işlem, CPU ile Wi-Fi’yi etkin tutarak Minecraft’ın çalışmaya devam etmesini sağlar.</string>
-    <string name="foreground_service_warning">Not: Telefonunuzun daha hızlı ısınmasına ve pil kullanımının artmasına neden olabilir.</string>
-    <string name="foreground_service_channel">Minecraft arka plan koruması</string>
-    <string name="foreground_service_notification_title">Minecraft etkin tutuluyor</string>
-    <string name="foreground_service_notification_text">Minecraft arka plan modu etkin. Geçerli oturum için CPU ve ağ erişimi kullanılabilir tutuluyor.</string>
-    <string name="mod_menu_compact">Kompakt Mod Menüsü</string>
-    <string name="mod_menu_compact_desc">Yoğun modül listesi ve kompakt filtrelerle daha küçük bir menü kullanın</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Hassasiyet Çarpanı (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Yatay Hız (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Dikey Hız (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Küçük Hareket Filtresi (0 = Kapalı)</string>
-    <string name="hud_editor_drag_hint">Paneli taşımak için sürükleyin</string>
-    <string name="hud_editor_drag_description">HUD Düzenleyici. Paneli taşımak için bu alanı sürükleyin.</string>
     <string name="mod_config_hotbar_item_icons">Hotbar’daki eşya simgelerini kullan</string>
     <string name="mod_config_hotbar_item_counts">Eşya sayısını göster</string>
     <string name="mod_config_hotbar_slot_enabled">Hotbar yuvası %1$d’yi göster</string>
     <string name="mod_config_hotbar_slot_size">Hotbar yuvası %1$d boyutu (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Hotbar yuvası %1$d opaklığı</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Yenilikler</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Devam Et</string>
@@ -1095,6 +1114,7 @@ LeviLauncher\'ın devam edebilmesi için taşımanın tamamlanması gerekiyor.</
     <string name="mod_config_category_button">Düğme</string>
     <string name="mod_config_visible_slots">Görünür Yuvalar</string>
     <string name="mod_config_hotbar_slot_section">Hotbar Yuvası %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Seç</string>
     <string name="select_all">Tümünü Seç</string>
     <string name="selected">Seçildi</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,3 +1,11 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -42,7 +50,7 @@
     <string name="loading">Đang tải…</string>
 
     <string name="import_confirmation_title">Nhập Mods</string>
-    <string name="import_confirmation_message">Bạn có chắc chắn muốn nhập Mod %d đã chọn không? </string>
+    <string name="import_confirmation_message">Bạn có chắc chắn muốn nhập Mod %d đã chọn không?</string>
     <string name="import_so_plugin_title">Nhập Plugin SO</string>
     <string name="plugin_name_label">Tên Plugin</string>
     <string name="plugin_type_label">Loại</string>
@@ -59,7 +67,7 @@
     <string name="local_custom">Chỉnh sửa cục bộ</string>
 
     <!-- Permissions -->
-    <string name="storage_permission_title">Quyền truy cập bộ nhớ </string>
+    <string name="storage_permission_title">Quyền truy cập bộ nhớ</string>
     <string name="storage_permission_message">Vui lòng cấp quyền truy cập bộ nhớ để LeviLauncher có thể sao chép dữ liệu từ thư mục games/org.levimc cũ. Quyền này chỉ cần thiết cho bước di chuyển dữ liệu.</string>
     <string name="grant_permission">Cấp quyền</string>
     <string name="cancel">Hủy</string>
@@ -72,7 +80,7 @@
     <string name="exit">Thoát</string>
 
     <string name="overlay_permission_message">Vui lòng cấp quyền hiển thị lớp phủ.</string>
-    <string name="overlay_permission_denied_message">Vui lòng cấp quyền hiển thị lớp phủ, nếu không cửa sổ nhật ký sẽ không thể hiển thị. </string>
+    <string name="overlay_permission_denied_message">Vui lòng cấp quyền hiển thị lớp phủ, nếu không cửa sổ nhật ký sẽ không thể hiển thị.</string>
     <string name="overlay_permission_not_granted">Quyền hiển thị lớp phủ đã bị từ chối</string>
     <string name="storage_permission_not_granted">Quyền truy cập bộ nhớ đã bị từ chối</string>
 
@@ -100,6 +108,7 @@
     <string name="settings_tab_personalize">Cá nhân hóa</string>
     <string name="settings_tab_updates">Cập nhật</string>
     <string name="settings_tab_about">Về</string>
+    <string name="settings_tab_migration">Di chuyển</string>
     <string name="settings_theme_desc">Chọn chủ đề cho ứng dụng</string>
 
 
@@ -107,7 +116,7 @@
     <string name="unknown_sources_permission_message">Để cài đặt hoặc cập nhật ứng dụng này, vui lòng cấp quyền cài đặt ứng dụng không rõ nguồn gốc. Nhấp vào "Cấp quyền" để mở cài đặt hệ thống, bật quyền cho ứng dụng này và quay lại để tiếp tục.</string>
 
     <string name="check_update">Kiểm tra cập nhật</string>
-    <string name="version_prefix">Phiên bản: </string>
+    <string name="version_prefix">Phiên bản:</string>
     <string name="unknown_error">Lỗi không xác định</string>
     <string name="preloader_sigs_title">Dữ liệu thời gian chạy</string>
     <string name="preloader_sigs_last_update">Cập nhật lần cuối: %1$s</string>
@@ -121,16 +130,18 @@
     <string name="dialog_title_no_version">Chưa chọn phiên bản</string>
     <string name="dialog_message_no_version">Vui lòng chọn phiên bản trò chơi trước khi khởi chạy.</string>
     <string name="dialog_title_version_isolation">Yêu cầu chia phiên bản</string>
-    <string name="dialog_message_version_isolation">Đây là phiên bản được nhập. Vui lòng bật tính năng chia phiên bản trong cài đặt để khởi chạy phiên bản này. </string>
+    <string name="dialog_message_version_isolation">Đây là phiên bản được nhập. Vui lòng bật tính năng chia phiên bản trong cài đặt để khởi chạy phiên bản này.</string>
     <string name="dialog_positive_enable">Bật</string>
     <string name="dialog_title_launch_failed">Khởi chạy không thành công</string>
     <string name="dialog_message_launch_failed">Không thể khởi chạy Minecraft: %1$s</string>
     <string name="dialog_title_incompatible_mods">Các bản mod không tương thích đã bị bỏ qua</string>
     <string name="dialog_message_incompatible_mods">Một số bản mod không tương thích với phiên bản Minecraft hiện tại của bạn %1$s và đã bị bỏ qua:\n\n%2$s</string>
     <string name="dialog_title_disable_version_isolation">Tắt tính năng chia phiên bản</string>
-    <string name="dialog_message_disable_version_isolation">Bạn đang cố gắng khởi chạy một phiên bản đã cài đặt với tính năng chia phiên bản được bật. Vui lòng tắt tính năng này để tiếp tục. </string>
+    <string name="dialog_message_disable_version_isolation">Bạn đang cố gắng khởi chạy một phiên bản đã cài đặt với tính năng chia phiên bản được bật. Vui lòng tắt tính năng này để tiếp tục.</string>
     <string name="dialog_positive_disable">Tắt</string>
     <string name="dialog_positive_ok">OK</string>
+    <string name="delete_account_title">Xóa tài khoản</string>
+    <string name="delete_account_confirm">Bạn có chắc muốn xóa tài khoản này không?</string>
 
 
     <string name="new_version_found">Đã tìm thấy phiên bản mới: %1$s</string>
@@ -159,11 +170,11 @@
     <string name="repair_preparing">Đang chuẩn bị…</string>
     <string name="repair_processing">Đang trích xuất thư viện…</string>
     <string name="repair_finalizing">Hoàn tất sửa chữa…</string>
-
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Cần có quyền chỉnh sửa kho lưu trữ</string>
     <string name="storage_migration_message">LeviLauncher phải di chuyển dữ liệu từ games/org.levimc sang %1$s trước khi tiếp tục.
 
-Việc thay đổi thư mục lưu trữ này là cần thiết để tuân thủ các quy định về hiển thị danh sách trên Google Play. Thư mục cũ sẽ được giữ nguyên, nhưng sẽ không còn được sử dụng sau khi chuyển đổi. 
+Việc thay đổi thư mục lưu trữ này là cần thiết để tuân thủ các quy định về hiển thị danh sách trên Google Play. Thư mục cũ sẽ được giữ nguyên, nhưng sẽ không còn được sử dụng sau khi chuyển đổi.
 
 Quá trình chuyển đổi có thể mất một lúc. Bạn có thể để ứng dụng chạy ngầm trong khi nó thực hiện; điện thoại có thể nóng lên trong quá trình sao chép tập tin lớn. Cảm ơn sự thông cảm của bạn.</string>
     <string name="storage_migration_start">Di chuyển</string>
@@ -171,7 +182,7 @@ Quá trình chuyển đổi có thể mất một lúc. Bạn có thể để �
     <string name="storage_migration_progress_title">Di chuyển dữ liệu</string>
     <string name="storage_migration_progress_subtitle">Đang sao chép dữ liệu Launcher vào thư mục Android/media</string>
     <string name="storage_migration_scanning">Đang quét thư mục cũ…</string>
-    <string name="storage_migration_progress_detail">%1$d/%2$d files · %3$s</string>
+    <string name="storage_migration_progress_detail">%1$d/%2$d tệp · %3$s</string>
     <string name="storage_migration_eta_pending">Ước tính thời gian còn lại…</string>
     <string name="storage_migration_eta_detail">Về %1$s còn lại · hoàn thành khoảng %2$s</string>
     <string name="storage_migration_duration_hours_minutes">%1$d giờ %2$d phút</string>
@@ -183,26 +194,42 @@ Quá trình chuyển đổi có thể mất một lúc. Bạn có thể để �
 
 Thư mục games/org.levimc cũ không bị xóa và không còn được sử dụng nữa.</string>
     <string name="storage_migration_partial_title">Di chuyển chưa hoàn tất</string>
-    <string name="storage_migration_partial_message">Không thể sao chép tập tin %1$d trong %2$d. Quá trình di chuyển phải hoàn tất trước khi LeviLauncher có thể tiếp tục. </string>
+    <string name="storage_migration_partial_message">Không thể sao chép tập tin %1$d trong %2$d. Quá trình di chuyển phải hoàn tất trước khi LeviLauncher có thể tiếp tục.</string>
     <string name="storage_migration_failed_title">Quá trình di chuyển thất bại</string>
     <string name="storage_migration_failed_message">Quá trình di chuyển không thể tiếp tục: %1$s
 
 Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có thể tiếp tục.</string>
-
+    <string name="migration_cleanup_title">Dọn thư mục lịch sử</string>
+    <string name="migration_cleanup_desc">Chỉ xóa thư mục games/org.levimc cũ sau khi bạn đã xác nhận mọi phiên bản đều khởi chạy bình thường và không thiếu thế giới, gói tài nguyên, gói hành vi hoặc cài đặt. Dữ liệu lịch sử đã xóa không thể khôi phục từ thư mục này.</string>
+    <string name="migration_cleanup_button">Dọn thư mục lịch sử</string>
+    <string name="migration_cleanup_confirm_title">Dọn thư mục lịch sử?</string>
+    <string name="migration_cleanup_confirm_message">Thao tác này sẽ xóa vĩnh viễn thư mục games/org.levimc cũ.\n\nTrước khi tiếp tục, hãy đảm bảo tất cả phiên bản đều khởi chạy bình thường và không thiếu thế giới, gói tài nguyên, gói hành vi hoặc cài đặt.</string>
+    <string name="migration_cleanup_unavailable_not_completed">Quá trình di chuyển bộ nhớ chưa hoàn tất. Hãy hoàn tất di chuyển trước khi dọn thư mục cũ.</string>
+    <string name="migration_cleanup_unavailable_missing">Không tìm thấy thư mục games/org.levimc cũ hoặc thư mục đã được dọn.</string>
+    <string name="migration_cleanup_ready">Có thể dọn thư mục cũ. Hãy xác nhận tất cả phiên bản đã di chuyển đều hoạt động bình thường trước khi tiếp tục.</string>
+    <string name="migration_cleanup_success">Đã dọn thư mục lịch sử: xóa %1$d tệp (%2$s).</string>
+    <string name="migration_cleanup_failed">Không thể dọn thư mục lịch sử: %1$s</string>
+    <string name="shared_storage_layout_title">Thư mục nội dung dùng chung</string>
+    <string name="shared_storage_layout_desc">Dùng thư mục _shared mới cho nội dung dùng chung Nội bộ và Bên ngoài. Tắt tùy chọn này để dùng các thư mục dữ liệu trò chơi nội bộ và bên ngoài ban đầu. Thao tác này không di chuyển tệp.</string>
+    <string name="shared_storage_layout_mode_new">Thư mục _shared mới</string>
+    <string name="shared_storage_layout_mode_legacy">Thư mục nội bộ/bên ngoài ban đầu</string>
+    <string name="shared_storage_layout_status">Chế độ hiện tại: %1$s\nNội bộ: %2$s\nBên ngoài: %3$s</string>
+    <string name="shared_storage_layout_changed">Lựa chọn thư mục lưu trữ đã được cập nhật. Hãy khởi động lại Minecraft và mở lại quản lý nội dung để thay đổi được áp dụng đầy đủ.</string>
+    <!-- Theme -->
     <string name="theme_title">Chế độ chủ đề</string>
     <string name="theme_follow_system">Theo hệ thống</string>
     <string name="theme_light">Sáng</string>
     <string name="theme_dark">Tối</string>
 
     <string name="error_no_browser">Không có trình duyệt nào khả dụng</string>
-
+    <!-- License & Security -->
     <string name="eula_title">Thỏa thuận cấp phép LeviLauncher</string>
     <string name="eula_message"><b>Chào mừng bạn đến với LeviLauncher</b>\n\nBằng cách sử dụng phần mềm này, bạn đồng ý với các điều khoản sau:\n\n• Đây là trình khởi chạy Minecraft  <b>không chính thức</b>\n• Bạn phải sở hữu một bản sao Minecraft <b>được cấp phép</b> \n• Mọi hình thức vi phạm bản quyền hoặc gian lận đều bị nghiêm cấm\n• Việc sử dụng các bản Mods/gói tài nguyên là do bạn tự chịu rủi ro\n• Không liên kết với Mojang/Microsoft\n\nViệc tiếp tục sử dụng đồng nghĩa với việc bạn đồng ý</string>
     <string name="eula_agree">Đồng ý</string>
     <string name="eula_exit">Từ chối</string>
 
-    <string name="allow_unknown_sources">Vui lòng cho phép cài đặt từ nguồn không xác định trước khi tiếp tục. </string>
-
+    <string name="allow_unknown_sources">Vui lòng cho phép cài đặt từ nguồn không xác định trước khi tiếp tục.</string>
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Xóa phiên bản</string>
     <string name="dialog_message_delete_version">Bạn có chắc chắn muốn xóa phiên bản tùy chỉnh này không? Thao tác này không thể hoàn tác.</string>
     <string name="dialog_positive_delete">Xóa</string>
@@ -211,9 +238,9 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="toast_delete_failed">Xóa không thành công: %1$s</string>
     <string name="error_delete_builtin_version">Không thể xóa phiên bản tích hợp sẵn</string>
     <string name="invalid_mod_file">Không thành công</string>
-    <string name="invalid_mod_file_reason">Chỉ cho phép files .so, gói mod .zip, hoặc gói mod .levipack | File đã chọn không phải là gói nhập mod hợp lệ. </string>
+    <string name="invalid_mod_file_reason">Chỉ cho phép tệp .so, gói mod .zip hoặc gói mod .levipack | Tệp đã chọn không phải là gói nhập mod hợp lệ.</string>
     <string name="invalid_zip_mod_package_title">Gói mod ZIP không hợp lệ</string>
-    <string name="invalid_zip_mod_package_message">Gói mod ZIP phải chứa file manifest.json và file .so. </string>
+    <string name="invalid_zip_mod_package_message">Gói mod ZIP phải chứa file manifest.json và file .so.</string>
     <string name="error_versions">Phiên bản lỗi</string>
 
     <string name="dialog_title_delete_mod">Xóa Mod</string>
@@ -222,7 +249,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="version_isolation">Chia phiên bản</string>
     <string name="launch_vertically">Khởi chạy theo chiều dọc</string>
     <string name="launch_vertically_desc">Buộc trò chơi khởi chạy ở chế độ dọc.</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Cài đặt cho phiên bản</string>
     <string name="instance_tab_general">Chung</string>
     <string name="instance_tab_launch_options">Tùy chọn khởi chạy</string>
@@ -233,6 +260,16 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="instance_clear_icon">Xóa</string>
     <string name="instance_icon_hint">Sẽ được lưu dưới dạng LargeLogo.png trong thư mục version. Nhấp vào biểu tượng để thay đổi.</string>
     <string name="instance_isolation_desc">Chỉ hiển thị dữ liệu trò chơi riêng cho phiên bản này. Các phiên bản khác sẽ không bị ảnh hưởng.</string>
+    <string name="instance_shortcut_title">Lối tắt màn hình chính</string>
+    <string name="instance_shortcut_desc">Thay đổi tên và biểu tượng được lưu tự động. Nhấn Thêm lối tắt để tạo hoặc cập nhật lối tắt trên màn hình chính.</string>
+    <string name="instance_shortcut_name">Tên lối tắt</string>
+    <string name="instance_shortcut_icon">Biểu tượng lối tắt</string>
+    <string name="instance_shortcut_choose_icon">Chọn biểu tượng</string>
+    <string name="instance_shortcut_default_icon">Dùng mặc định</string>
+    <string name="instance_shortcut_add_button">Thêm lối tắt</string>
+    <string name="instance_settings_auto_save_failed">Không thể lưu cài đặt phiên bản này.</string>
+    <string name="instance_shortcut_not_supported">Trình khởi chạy màn hình chính của bạn không hỗ trợ lối tắt được ghim.</string>
+    <string name="instance_shortcut_missing">Phiên bản Minecraft này không còn khả dụng.</string>
     <string name="instance_danger_zone">Khu vực nguy hiểm</string>
     <string name="instance_danger_zone_desc">Các thao tác này ảnh hưởng đến việc đăng ký phiên bản hoặc các file cục bộ. Hãy kiểm tra kỹ trước khi tiếp tục.</string>
     <string name="instance_delete_desc">Thao tác này sẽ xóa vĩnh viễn phiên bản này khỏi thiết bị của bạn, bao gồm cả thế giới, cấu hình và nội dung đã cài đặt.</string>
@@ -270,6 +307,8 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="instance_restore_failed_message">Không thể khôi phục bản sao lưu:\n%1$s</string>
 
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">ngôn ngữ (Language)</string>
     <string name="english">Tiếng Anh (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -304,8 +343,8 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="skin_packs_category">Gói ngoại hình</string>
     <string name="screenshots_category">Ảnh chụp màn hình</string>
     <string name="servers_category">Máy chủ</string>
-    <string name="storage_internal">Internal</string>
-    <string name="storage_external">External</string>
+    <string name="storage_internal">Bộ nhớ trong</string>
+    <string name="storage_external">Bộ nhớ ngoài</string>
     <string name="storage_version_isolation">Chia phiên bản</string>
     <string name="select_storage_label">Chọn kho lưu trữ:</string>
     <string name="search_hint">Tìm kiếm…</string>
@@ -363,6 +402,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="edit_world">Chỉnh sửa thế giới</string>
     <string name="edit">Chỉnh sửa</string>
     <string name="save">Lưu</string>
+    <string name="reset">Đặt lại</string>
     <string name="saved_to_gallery">Đã lưu vào thư viện ảnh</string>
     <string name="level_dat_not_found">Không tìm thấy file level.dat</string>
     <string name="no_editable_properties">Không tìm thấy thuộc tính nào có thể chỉnh sửa.</string>
@@ -387,6 +427,20 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="add_at_least_one_layer">Thêm ít nhất một lớp</string>
     <string name="world_created_successfully">Thế giới đã được tạo thành công</string>
     <string name="failed_to_create_world">Tạo thế giới thất bại</string>
+    <string name="custom_flat_world_subtitle">Tạo thế giới với quần xã và các lớp khối của riêng bạn</string>
+    <string name="world_settings">Cài đặt thế giới</string>
+    <string name="world_settings_hint">Chọn các cài đặt cơ bản cho thế giới mới</string>
+    <string name="layers_title">Các lớp</string>
+    <string name="add_layer_compact">Thêm lớp</string>
+    <string name="no_layers_title">Chưa có lớp nào</string>
+    <string name="no_layers_hint">Thêm ít nhất một lớp khối để tạo thế giới</string>
+    <string name="reorder_layer">Sắp xếp lại lớp</string>
+    <string name="delete_layer">Xóa lớp</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d lớp • dưới → trên</item>
+        <item quantity="other">%1$d lớp • dưới → trên</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">Cần có phiên bản Play Store</string>
@@ -398,10 +452,57 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="genuine_badge_label">Giấy phép chưa được xác minh</string>
     <string name="invalid_license_detected_toast">Đã phát hiện Minecraft không phải bản chính hãng. Hãy đảm bảo Minecraft của bạn được tải từ Google Play Store.</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Tổng các Mods:</string>
     <string name="enabled_mods">Đã bật:</string>
     <string name="add_mod">Thêm Mod</string>
+    <string name="scan_downloads">Quét</string>
+    <string name="scan_downloads_scanning">Đang quét…</string>
+    <string name="scan_downloads_none_found">Không tìm thấy mod .levipack hoặc .so trong Tải xuống</string>
+    <string name="scan_downloads_failed">Không thể quét thư mục Tải xuống</string>
+    <string name="scan_downloads_permission_denied">Cần quyền truy cập bộ nhớ để quét thư mục Tải xuống</string>
+    <string name="scan_downloads_results_title">Mod trong Tải xuống</string>
+    <string name="scan_downloads_results_subtitle">Chọn mod để thêm. Quét chỉ kiểm tra thư mục Tải xuống chính.</string>
+    <string name="scan_downloads_add">Thêm</string>
+    <string name="scan_downloads_adding">Đang thêm…</string>
+    <string name="scan_downloads_added">Đã thêm</string>
+    <string name="scan_downloads_added_message">Đã thêm %1$s</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">Thư viện native</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">Mod bên ngoài</string>
+    <string name="external_mods_subtitle">Mod cộng đồng cho Minecraft %1$s</string>
+    <string name="external_mods_no_version">Chọn phiên bản Minecraft trước khi cài mod</string>
+    <string name="external_mods_search_hint">Tìm mod, tác giả hoặc phiên bản…</string>
+    <string name="external_mods_compatible_only">Chỉ tương thích</string>
+    <string name="external_mods_all_versions">Tất cả phiên bản Minecraft</string>
+    <string name="external_mods_sort_newest">Mới nhất</string>
+    <string name="external_mods_sort_name">Tên A–Z</string>
+    <string name="external_mods_empty">Không có mod nào khớp với các bộ lọc này</string>
+    <string name="external_mods_load_failed">Không thể làm mới danh mục. Đang hiển thị bản đã lưu.</string>
+    <string name="external_mods_refresh">Làm mới danh mục</string>
+    <string name="external_mods_refreshed">Đã làm mới danh mục</string>
+    <string name="external_mods_join_discord">Tham gia Discord cộng đồng</string>
+    <string name="external_mods_discord_open_failed">Không có ứng dụng nào có thể mở lời mời Discord</string>
+    <string name="external_mods_download">Đang tải %1$s</string>
+    <string name="external_mods_importing">Đang nhập mod…</string>
+    <string name="external_mods_installed">Đã cài %1$s</string>
+    <string name="external_mods_install_failed">Không thể cài %1$s: %2$s</string>
+    <string name="external_mods_open_failed">Không có trình duyệt nào có thể mở bản tải xuống này</string>
+    <string name="external_mods_direct_download">Tải trực tiếp</string>
+    <string name="external_mods_ad_download">Tải có quảng cáo</string>
+    <string name="external_mods_external_link">Liên kết ngoài</string>
+    <string name="external_mods_open_link">Mở liên kết</string>
+    <string name="external_mods_external_dialog_title">Tải xuống bên ngoài</string>
+    <string name="external_mods_ad_dialog_title">Tải xuống có quảng cáo</string>
+    <string name="external_mods_external_dialog_message">%1$s sử dụng trang tải xuống bên ngoài LeviLauncher.\n\n1. Nhấn Mở liên kết và tải tệp .levipack hoặc .so.\n2. Quay lại LeviLauncher và mở Mod.\n3. Nhấn Quét.\n4. Nhấn Thêm bên cạnh mod bạn muốn nhập.\n\nQuét chỉ kiểm tra thư mục Tải xuống chính. Hãy chuyển tệp vào đó nếu trình duyệt đã lưu ở nơi khác.</string>
+    <string name="external_mods_ad_dialog_message">%1$s sử dụng trang tải xuống có quảng cáo do nhà phát triển chọn. LeviLauncher không kiểm soát trang đó hoặc quảng cáo trên đó.\n\n1. Nhấn Mở liên kết và tải tệp .levipack hoặc .so.\n2. Quay lại LeviLauncher và mở Mod.\n3. Nhấn Quét.\n4. Nhấn Thêm bên cạnh mod bạn muốn nhập.\n\nQuét chỉ kiểm tra thư mục Tải xuống chính. Chỉ tải tệp mod; không cài ứng dụng không liên quan hoặc cho phép thông báo.</string>
+    <string name="external_mods_by_author">bởi %1$s</string>
+    <string name="external_mods_version">Mod %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">Cập nhật</string>
+    <string name="external_mods_installed_button">Đã cài</string>
+    <string name="external_mods_incompatible">Không tương thích</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">Chi tiết bản Mod</string>
@@ -419,7 +520,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="mod_author_label">Tác giả</string>
     <string name="mod_version_label">Phiên bản</string>
     <string name="mod_minecraft_versions_label">Các phiên bản Minecraft</string>
-    <string name="mod_entry_label">Entry File</string>
+    <string name="mod_entry_label">Tệp chính</string>
     <string name="mod_id_label">Mod ID</string>
     <string name="mod_config_files_label">Cấu hình Files</string>
     <string name="mod_unknown_author">Không rõ Tác giả</string>
@@ -433,7 +534,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="mod_config_load_failed">Không thể tải cấu hình: %s</string>
     <string name="mod_config_save_failed">Không thể lưu cấu hình</string>
     <string name="mod_config_saved">Cấu hình đã được lưu</string>
-    <string name="mod_config_restart_hint">File cấu hình đã được lưu và một file .backup đã được giữ lại. Khởi động lại hoặc tải lại trò chơi để các thay đổi có hiệu lực. </string>
+    <string name="mod_config_restart_hint">Tệp cấu hình đã được lưu và một tệp .backup đã được giữ lại. Khởi động lại hoặc tải lại trò chơi để các thay đổi có hiệu lực.</string>
     <string name="mod_config_validation_failed">Xác thực cấu hình thất bại</string>
     <string name="mod_config_invalid_json">JSON không hợp lệ</string>
     <string name="mod_config_expand">Mở rộng</string>
@@ -449,7 +550,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="mod_config_error_maximum">%1$s tối đa phải là %2$s</string>
     <string name="mod_config_error_boolean">%1$s phải bật hoặc tắt</string>
     <string name="mod_config_error_string">%1$s phải là văn bản</string>
-
+    <!-- Mod Configuration -->
     <plurals name="mod_config_files_count">
         <item quantity="one">%d cấu hình có thể chỉnh sửa</item>
         <item quantity="other">%d các cấu hình có thể chỉnh sửa</item>
@@ -492,13 +593,45 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="accounts_active_privilege">Đã đăng nhập</string>
 
     <string name="ms_login_title">Đăng nhập Microsoft</string>
+    <string name="ms_login_header_subtitle">Đăng nhập Minecraft an toàn</string>
     <string name="ms_login_starting">Đang bắt đầu đăng nhập Microsoft…</string>
     <string name="ms_login_exchanging">Đang trao đổi token…</string>
     <string name="ms_login_auth_xbox_device">Đang xác thực thiết bị Xbox…</string>
     <string name="ms_login_fetch_minecraft_identity">Đang lấy thông tin nhận dạng Minecraft…</string>
+    <string name="ms_login_retrying">Kết nối bị gián đoạn. Đang thử lại an toàn…</string>
     <string name="ms_login_success">Đăng nhập với tư cách %1$s</string>
     <string name="ms_login_failed">Đăng nhập Microsoft thất bại</string>
     <string name="ms_login_failed_detail">Đăng nhập thất bại: %1$s</string>
+    <string name="ms_choose_login_method">Đăng nhập vào Minecraft</string>
+    <string name="ms_choose_login_method_desc">Chọn luồng mã thiết bị qua trình duyệt hoặc tiếp tục bằng trang Microsoft nhúng.</string>
+    <string name="ms_device_code_login">Tiếp tục bằng trình duyệt</string>
+    <string name="ms_device_code_option_title">Mã thiết bị (Khuyến nghị)</string>
+    <string name="ms_device_code_login_desc">Mở phiên trình duyệt riêng tư với mã thiết bị đã được điền sẵn.</string>
+    <string name="ms_webview_login">Mở đăng nhập nhúng</string>
+    <string name="ms_webview_option_title">WebView nhúng</string>
+    <string name="ms_webview_login_desc">Đăng nhập mà không rời LeviLauncher. Dùng tùy chọn này khi luồng trình duyệt không khả dụng.</string>
+    <string name="ms_device_code_title">Đăng nhập bằng Mã thiết bị</string>
+    <string name="ms_device_code_instructions">Mở trang đăng nhập thiết bị của Microsoft, nhập mã này rồi chấp thuận quyền truy cập. LeviLauncher sẽ tự động hoàn tất.</string>
+    <string name="ms_device_code_label">Mã thiết bị Microsoft</string>
+    <string name="ms_device_code_requesting">Đang yêu cầu mã bảo mật…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">Đang chờ bạn hoàn tất trong trình duyệt…</string>
+    <string name="ms_device_code_checking">Đang kiểm tra kết quả đăng nhập Microsoft…</string>
+    <string name="ms_device_code_reconnecting">Kết nối đã thay đổi. Đang tự động thử lại…</string>
+    <string name="ms_device_code_authorized">Microsoft đã phê duyệt đăng nhập. Đang hoàn tất…</string>
+    <string name="ms_device_code_browser_opened">Hoàn tất đăng nhập Microsoft mới trong trình duyệt rồi quay lại đây.</string>
+    <string name="ms_device_code_expires">Mã hết hạn sau %1$d:%2$02d</string>
+    <string name="ms_device_code_copy">Sao chép mã</string>
+    <string name="ms_device_code_copied">Đã sao chép mã</string>
+    <string name="ms_device_code_open_browser">Mở đăng nhập Microsoft</string>
+    <string name="ms_device_code_step_title">Hoàn tất đăng nhập trong trình duyệt</string>
+    <string name="ms_device_code_browser_note">LeviLauncher mở trình duyệt mặc định trong phiên riêng tư, tự động điền mã và yêu cầu đăng nhập Microsoft mới.</string>
+    <string name="ms_choose_other_method">Phương thức khác</string>
+    <string name="ms_no_browser">Không có trình duyệt nào trên thiết bị này.</string>
+    <string name="ms_default_browser_no_private_mode">Trình duyệt mặc định của bạn không hỗ trợ đăng nhập riêng tư. Hãy cập nhật hoặc dùng đăng nhập WebView.</string>
+    <string name="ms_login_ssl_failed">Không thể xác minh trang đăng nhập Microsoft bảo mật.</string>
+    <string name="ms_login_state_failed">Không thể xác minh phản hồi đăng nhập Microsoft. Hãy bắt đầu đăng nhập lại.</string>
+    <string name="ms_login_missing_code">Microsoft không trả về mã đăng nhập. Hãy bắt đầu đăng nhập lại hoặc dùng Mã thiết bị.</string>
 
     <string name="ms_set_active">Đặt trạng thái hoạt động</string>
     <string name="ms_delete">Xóa</string>
@@ -511,10 +644,14 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="go_to_accounts">Tài khoản</string>
     <string name="disable_launcher_login_and_continue">Đóng</string>
 
+    <string name="ms_feature_disabled_title">Tính năng bị tắt</string>
+    <string name="ms_feature_disabled_desc">Hãy bật “Đăng nhập Minecraft bằng LeviLauncher” trong Cài đặt để quản lý tài khoản Microsoft.</string>
+    <string name="ms_activated">Đã kích hoạt</string>
+
     <!-- Popup labels -->
     <string name="label_current_account">Tài khoản hiện tại</string>
     <string name="label_other_accounts">Các tài khoản khác</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">Ứng dụng bị lỗi</string>
     <string name="crash_upload">Tải lên báo cáo sự cố</string>
     <string name="crash_details_title">Chi tiết lỗi</string>
@@ -527,12 +664,18 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="crash_type_label">Loại sự cố:</string>
     <string name="crash_summary_label">Tóm tắt sự cố:</string>
     <string name="crash_stack_label">Chi tiết sự cố và ngăn xếp:</string>
-    <string name="crash_emergency_label">Emergency:</string>
+    <string name="crash_emergency_label">Khẩn cấp:</string>
     <string name="crash_no_details">Không có thông tin chi tiết về lỗi.</string>
     <string name="dialog_title_exit_app">Thoát ứng dụng</string>
     <string name="dialog_message_exit_app">Bạn có chắc chắn muốn thoát ra không?</string>
     <string name="dialog_positive_exit">Thoát</string>
     <string name="show_logcat_overlay">Lớp phủ Logcat</string>
+    <string name="foreground_service">Dịch vụ tiền cảnh</string>
+    <string name="foreground_service_desc">Giữ Minecraft tiếp tục chạy khi bạn chuyển ứng dụng bằng cách ngăn Bedrock tạm dừng phiên đang hoạt động và giữ tiến trình, CPU cùng Wi-Fi luôn hoạt động.</string>
+    <string name="foreground_service_warning">Lưu ý: Có thể khiến điện thoại nóng nhanh hơn và tăng mức sử dụng pin.</string>
+    <string name="foreground_service_channel">Bảo vệ Minecraft khi chạy nền</string>
+    <string name="foreground_service_notification_title">Minecraft đang được giữ hoạt động</string>
+    <string name="foreground_service_notification_text">Chế độ nền của Minecraft đang hoạt động. CPU và quyền truy cập mạng được duy trì cho phiên hiện tại.</string>
     <string name="logcat_live">Logcat: <b>trực tiếp</b></string>
     <string name="logcat_paused">Logcat: đã tạm dừng</string>
     <!-- Logcat Overlay i18n -->
@@ -581,16 +724,24 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="inbuilt_mod_snaplook">Snaplook</string>
     <string name="inbuilt_mod_snaplook_desc">Giữ nút để nhanh chóng nhìn ra phía sau. (third person front)</string>
     <string name="inbuilt_mod_virtual_cursor">Con trỏ ảo</string>
-    <string name="inbuilt_mod_virtual_cursor_desc">Sử dụng virtual trackpad để điều khiển chuột. </string>
+    <string name="inbuilt_mod_virtual_cursor_desc">Sử dụng virtual trackpad để điều khiển chuột.</string>
     <string name="virtual_cursor_enabled">Con trỏ đã được bật</string>
     <string name="virtual_cursor_disabled">Con trỏ chuột đã tắt</string>
     <string name="cursor_sensitivity_label">Độ nhạy của con trỏ:</string>
+    <string name="inbuilt_mod_gyro">Con quay hồi chuyển</string>
+    <string name="inbuilt_mod_gyro_desc">Dùng con quay hồi chuyển của thiết bị để điều khiển xoay camera</string>
+    <string name="inbuilt_mod_pojav_controls">Điều khiển Pojav</string>
+    <string name="inbuilt_mod_pojav_controls_desc">Thay điều khiển cảm ứng Minecraft bằng điều khiển kiểu Pojav có thể tùy chỉnh hoàn toàn</string>
+    <string name="inbuilt_mod_more_buttons">Thêm nút</string>
+    <string name="inbuilt_mod_more_buttons_desc">Tạo các nút tùy chỉnh trên màn hình với ánh xạ một phím và biểu tượng SVG</string>
     <string name="inbuilt_badge">TÍCH HỢP SẴN</string>
     <string name="autosprint_keybind_label">Phím tắt tự động chạy nhanh:</string>
     <string name="autosprint_keybind_press">Nhấn bất kỳ phím nào…</string>
     <string name="configure">Cấu hình</string>
     <string name="overlay_button_size">Kích thước nút</string>
     <string name="overlay_button_opacity">Độ mờ của nút</string>
+    <string name="overlay_button_size_value">Kích thước: %1$ddp</string>
+    <string name="overlay_button_opacity_value">Độ mờ: %1$d%%</string>
     <string name="overlay_button_lock">Khóa vị trí</string>
     <string name="overlay_button_lock_desc">Ngăn chặn việc kéo lê và kích hoạt ngoài ý muốn.</string>
     <string name="settings">Cài đặt</string>
@@ -610,15 +761,35 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="structures_found_count">Tìm thấy %d cấu trúc trên thế giới này</string>
 
     <!-- Mod Menu -->
-    <string name="mod_menu">Mod Menu</string>
+    <string name="mod_menu">Menu mod</string>
     <string name="mod_menu_modules">Mô-đun</string>
+    <string name="mod_menu_favorites">Yêu thích</string>
+    <string name="mod_menu_favorite">Thêm vào yêu thích</string>
+    <string name="mod_menu_unfavorite">Xóa khỏi yêu thích</string>
+    <string name="mod_menu_hud_editor">Trình chỉnh sửa HUD</string>
+    <string name="mod_menu_filter_enabled">Đã bật</string>
+    <string name="mod_menu_filter_inbuilt">Tích hợp</string>
+    <string name="mod_menu_filter_external">Bên ngoài</string>
     <string name="mod_menu_search_hint">Tìm mods…</string>
     <string name="mod_menu_no_mods">Không có bản mods nào được thêm vào.</string>
+    <string name="mod_menu_no_favorites">Chưa có mod yêu thích</string>
+    <string name="mod_menu_no_matches">Không có mod phù hợp</string>
+    <string name="mod_menu_group_inbuilt">Tính năng tích hợp</string>
+    <string name="mod_menu_group_external_ungrouped">Mod bên ngoài chưa nhóm</string>
+    <string name="mod_menu_module_count">%1$d / %2$d</string>
+    <string name="mod_menu_general_settings">Cài đặt chung</string>
+    <string name="mod_menu_appearance">Giao diện</string>
+    <string name="mod_menu_pause_menu_only">Chỉ trong menu tạm dừng</string>
+    <string name="mod_menu_pause_menu_only_desc">Chỉ hiển thị menu mod ở màn hình tạm dừng</string>
+    <string name="mod_menu_default_percent" formatted="false">100%</string>
+    <string name="mod_menu_percent_value">%1$d%%</string>
     <string name="mod_menu_settings_coming">Các cài đặt sẽ sớm được cập nhật.</string>
     <string name="mod_menu_notifications">Thông báo</string>
     <string name="mod_menu_notifications_desc">Hiển thị thông báo khi bật mods</string>
     <string name="mod_menu_opacity">Độ mờ của Mod Menu</string>
     <string name="mod_menu_button_opacity">Độ mờ của nút Mod Menu</string>
+    <string name="mod_menu_compact">Menu Mod gọn</string>
+    <string name="mod_menu_compact_desc">Dùng menu nhỏ hơn với danh sách mô-đun dày hơn và bộ lọc gọn</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">Mod Menu đã bật</string>
     <string name="mod_menu_disabled">Mod Menu đã tắt</string>
@@ -627,6 +798,35 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="mod_status_enabled">Đã bật</string>
     <string name="mod_status_disabled">Đã tắt</string>
     <string name="mod_notification_enabled">%s đã bật</string>
+    <string name="mod_overlay_fps_unknown">FPS: --</string>
+    <string name="mod_overlay_fps_value">FPS: %1$d</string>
+    <string name="mod_overlay_cps_value">CPS: %1$d</string>
+    <string name="mod_config_overlay_button_size_dp">Kích thước nút overlay (dp)</string>
+    <string name="mod_config_overlay_opacity_percent" formatted="false">Độ mờ overlay (%)</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">Hiển thị mọi nơi</string>
+    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Độ nhạy con trỏ (%)</string>
+    <string name="mod_config_zoom_level_percent" formatted="false">Mức thu phóng (%)</string>
+    <string name="mod_config_auto_sprint_keybind">Phím tự động chạy</string>
+    <string name="mod_config_zoom_keybind">Phím thu phóng</string>
+    <string name="mod_config_zoom_transition">Thời lượng chuyển đổi (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Hệ số độ nhạy (100% = 1x)</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">Tốc độ ngang (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">Tốc độ dọc (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">Bộ lọc chuyển động nhỏ (0 = Tắt)</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">Độ nhạy ngang (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">Độ nhạy dọc (%)</string>
+    <string name="mod_config_gyro_invert_x">Đảo trục ngang</string>
+    <string name="mod_config_gyro_invert_y">Đảo trục dọc</string>
+    <string name="mod_config_gyro_deadzone">Vùng chết</string>
+    <string name="mod_config_press_any_key">Nhấn phím bất kỳ để gán...</string>
+    <string name="mod_config_key_unknown">KHÔNG RÕ</string>
+    <string name="mod_config_color_alpha_short">A</string>
+    <string name="mod_config_color_red_short">R</string>
+    <string name="mod_config_color_green_short">G</string>
+    <string name="mod_config_color_blue_short">B</string>
+    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">Kéo để di chuyển bảng</string>
+    <string name="hud_editor_drag_description">Trình chỉnh sửa HUD. Kéo khu vực này để di chuyển bảng.</string>
 
     <!-- Options Editor -->
     <string name="edit_options">Chỉnh sửa tùy chọn</string>
@@ -645,7 +845,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="quick_launch_servers_tab">Tab Máy chủ</string>
     <string name="quick_launch_servers_tab_desc">Mở tab máy chủ trong menu trò chơi.</string>
     <string name="quick_launch_profile">Hồ sơ / Phòng thay đồ</string>
-    <string name="quick_launch_profile_desc">Mở màn hình tùy chỉnh nhân vật của bạn </string>
+    <string name="quick_launch_profile_desc">Mở màn hình tùy chỉnh nhân vật của bạn</string>
     <string name="quick_launch_store_home">Trang chủ Marketplace</string>
     <string name="quick_launch_store_home_desc">Mở màn hình chính của Marketplace</string>
     <string name="quick_launch_minecoins">Minecoins</string>
@@ -684,7 +884,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="invite_code_required">Cần có mã mời.</string>
     <string name="world_name_required">Tên thế giới là bắt buộc</string>
     <string name="command_required">Lệnh này là bắt buộc</string>
-    <string name="invalid_minecraft_uri">URI minecraft:// không hợp lệ </string>
+    <string name="invalid_minecraft_uri">URI minecraft:// không hợp lệ</string>
 
     <!-- Quick Launch Actions -->
     <string name="connect">Kết nối</string>
@@ -704,7 +904,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="curseforge_downloading">Đang tải xuống…</string>
     <string name="curseforge_importing">Đang nhập…</string>
     <string name="curseforge_download_failed">Tải xuống thất bại</string>
-    <string name="curseforge_available_files">Các file có sẵn </string>
+    <string name="curseforge_available_files">Các tệp có sẵn</string>
 
     <!-- Navigation Bar -->
     <string name="nav_launch">Khởi chạy</string>
@@ -741,7 +941,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="about_star_fork">Star / Fork</string>
 
     <string-array name="launcher_tips">
-       <item>Phần Cài đặt cho phép bạn điều chỉnh chủ đề, màu sắc, hình nền và các tùy chọn hiển thị khác sao cho phù hợp với thiết lập của mình.</item>
+        <item>Phần Cài đặt cho phép bạn điều chỉnh chủ đề, màu sắc, hình nền và các tùy chọn hiển thị khác sao cho phù hợp với thiết lập của mình.</item>
         <item>LeviLauncher là mã nguồn mở. Vui lòng sử dụng GitHub Issues để báo cáo sự cố hoặc đề xuất cải tiến.</item>
         <item>Sử dụng menu thả xuống phiên bản để nhanh chóng chuyển đổi giữa các phiên bản hiện tại.</item>
         <item>Liệu mọi người có thực sự đọc những thứ này không:)?</item>
@@ -753,7 +953,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
         <item>CurseForge cho phép bạn duyệt và tải xuống nội dung do cộng đồng trực tiếp thực hiện.</item>
         <item>Nhập các bản mod để mở rộng hoặc nâng cao các tính năng và hiệu năng của Minecraft.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Màu chủ đề</string>
     <string name="theme_color_desc">Màu nhấn chủ đạo của ứng dụng</string>
     <string name="preset_colors">MÀU SẮC CÀI SẴN</string>
@@ -771,112 +971,8 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
 
     <string name="unsupported_version_title">Phiên bản không được hỗ trợ</string>
     <string name="unsupported_version_msg">Trình khởi chạy này không hỗ trợ các phiên bản Minecraft cũ hơn 1.21.80</string>
-    <!-- Mod Menu synced translations -->
-    <string name="mod_menu_favorites">Yêu thích</string>
-    <string name="mod_menu_favorite">Thêm vào yêu thích</string>
-    <string name="mod_menu_unfavorite">Xóa khỏi yêu thích</string>
-    <string name="mod_menu_hud_editor">Trình chỉnh sửa HUD</string>
-    <string name="mod_menu_filter_enabled">Đã bật</string>
-    <string name="mod_menu_filter_inbuilt">Tích hợp</string>
-    <string name="mod_menu_filter_external">Bên ngoài</string>
-    <string name="mod_menu_no_favorites">Chưa có mod yêu thích</string>
-    <string name="mod_menu_no_matches">Không có mod phù hợp</string>
-    <string name="mod_menu_group_inbuilt">Tính năng tích hợp</string>
-    <string name="mod_menu_group_external_ungrouped">Mod bên ngoài chưa nhóm</string>
-    <string name="mod_menu_module_count">%1$d / %2$d</string>
-    <string name="mod_menu_general_settings">Cài đặt chung</string>
-    <string name="mod_menu_appearance">Giao diện</string>
-    <string name="mod_menu_pause_menu_only">Chỉ trong menu tạm dừng</string>
-    <string name="mod_menu_pause_menu_only_desc">Chỉ hiển thị menu mod ở màn hình tạm dừng</string>
-    <string name="mod_menu_default_percent" formatted="false">100%</string>
-    <string name="mod_menu_percent_value">%1$d%%</string>
-    <string name="mod_overlay_fps_unknown">FPS: --</string>
-    <string name="mod_overlay_fps_value">FPS: %1$d</string>
-    <string name="mod_overlay_cps_value">CPS: %1$d</string>
-    <string name="mod_config_overlay_button_size_dp">Kích thước nút overlay (dp)</string>
-    <string name="mod_config_overlay_opacity_percent" formatted="false">Độ mờ overlay (%)</string>
-    <string name="mod_config_cursor_sensitivity_percent" formatted="false">Độ nhạy con trỏ (%)</string>
-    <string name="mod_config_zoom_level_percent" formatted="false">Mức thu phóng (%)</string>
-    <string name="mod_config_auto_sprint_keybind">Phím tự động chạy</string>
-    <string name="mod_config_zoom_keybind">Phím thu phóng</string>
-    <string name="mod_config_press_any_key">Nhấn phím bất kỳ để gán...</string>
-    <string name="mod_config_key_unknown">KHÔNG RÕ</string>
-    <string name="mod_config_color_alpha_short">A</string>
-    <string name="mod_config_color_red_short">R</string>
-    <string name="mod_config_color_green_short">G</string>
-    <string name="mod_config_color_blue_short">B</string>
-    <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
-    <string name="overlay_button_size_value">Kích thước: %1$ddp</string>
-    <string name="overlay_button_opacity_value">Độ mờ: %1$d%%</string>
-    <string name="reset">Đặt lại</string>
-    <!-- Completed localization coverage -->
-    <string name="settings_tab_migration">Di chuyển</string>
-    <string name="delete_account_title">Xóa tài khoản</string>
-    <string name="delete_account_confirm">Bạn có chắc muốn xóa tài khoản này không?</string>
-    <string name="migration_cleanup_title">Dọn thư mục lịch sử</string>
-    <string name="migration_cleanup_desc">Chỉ xóa thư mục games/org.levimc cũ sau khi bạn đã xác nhận mọi phiên bản đều khởi chạy bình thường và không thiếu thế giới, gói tài nguyên, gói hành vi hoặc cài đặt. Dữ liệu lịch sử đã xóa không thể khôi phục từ thư mục này.</string>
-    <string name="migration_cleanup_button">Dọn thư mục lịch sử</string>
-    <string name="migration_cleanup_confirm_title">Dọn thư mục lịch sử?</string>
-    <string name="migration_cleanup_confirm_message">Thao tác này sẽ xóa vĩnh viễn thư mục games/org.levimc cũ.\n\nTrước khi tiếp tục, hãy đảm bảo tất cả phiên bản đều khởi chạy bình thường và không thiếu thế giới, gói tài nguyên, gói hành vi hoặc cài đặt.</string>
-    <string name="migration_cleanup_unavailable_not_completed">Quá trình di chuyển bộ nhớ chưa hoàn tất. Hãy hoàn tất di chuyển trước khi dọn thư mục cũ.</string>
-    <string name="migration_cleanup_unavailable_missing">Không tìm thấy thư mục games/org.levimc cũ hoặc thư mục đã được dọn.</string>
-    <string name="migration_cleanup_ready">Có thể dọn thư mục cũ. Hãy xác nhận tất cả phiên bản đã di chuyển đều hoạt động bình thường trước khi tiếp tục.</string>
-    <string name="migration_cleanup_success">Đã dọn thư mục lịch sử: xóa %1$d tệp (%2$s).</string>
-    <string name="migration_cleanup_failed">Không thể dọn thư mục lịch sử: %1$s</string>
-    <string name="shared_storage_layout_title">Thư mục nội dung dùng chung</string>
-    <string name="shared_storage_layout_desc">Dùng thư mục _shared mới cho nội dung dùng chung Nội bộ và Bên ngoài. Tắt tùy chọn này để dùng các thư mục dữ liệu trò chơi nội bộ và bên ngoài ban đầu. Thao tác này không di chuyển tệp.</string>
-    <string name="shared_storage_layout_mode_new">Thư mục _shared mới</string>
-    <string name="shared_storage_layout_mode_legacy">Thư mục nội bộ/bên ngoài ban đầu</string>
-    <string name="shared_storage_layout_status">Chế độ hiện tại: %1$s\nNội bộ: %2$s\nBên ngoài: %3$s</string>
-    <string name="shared_storage_layout_changed">Lựa chọn thư mục lưu trữ đã được cập nhật. Hãy khởi động lại Minecraft và mở lại quản lý nội dung để thay đổi được áp dụng đầy đủ.</string>
-    <string name="ms_login_header_subtitle">Đăng nhập Minecraft an toàn</string>
-    <string name="ms_login_retrying">Kết nối bị gián đoạn. Đang thử lại an toàn…</string>
-    <string name="ms_choose_login_method">Đăng nhập vào Minecraft</string>
-    <string name="ms_choose_login_method_desc">Chọn luồng mã thiết bị qua trình duyệt hoặc tiếp tục bằng trang Microsoft nhúng.</string>
-    <string name="ms_device_code_login">Tiếp tục bằng trình duyệt</string>
-    <string name="ms_device_code_option_title">Mã thiết bị (Khuyến nghị)</string>
-    <string name="ms_device_code_login_desc">Mở phiên trình duyệt riêng tư với mã thiết bị đã được điền sẵn.</string>
-    <string name="ms_webview_login">Mở đăng nhập nhúng</string>
-    <string name="ms_webview_option_title">WebView nhúng</string>
-    <string name="ms_webview_login_desc">Đăng nhập mà không rời LeviLauncher. Dùng tùy chọn này khi luồng trình duyệt không khả dụng.</string>
-    <string name="ms_device_code_title">Đăng nhập bằng Mã thiết bị</string>
-    <string name="ms_device_code_instructions">Mở trang đăng nhập thiết bị của Microsoft, nhập mã này rồi chấp thuận quyền truy cập. LeviLauncher sẽ tự động hoàn tất.</string>
-    <string name="ms_device_code_label">Mã thiết bị Microsoft</string>
-    <string name="ms_device_code_requesting">Đang yêu cầu mã bảo mật…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">Đang chờ bạn hoàn tất trong trình duyệt…</string>
-    <string name="ms_device_code_checking">Đang kiểm tra kết quả đăng nhập Microsoft…</string>
-    <string name="ms_device_code_reconnecting">Kết nối đã thay đổi. Đang tự động thử lại…</string>
-    <string name="ms_device_code_authorized">Microsoft đã phê duyệt đăng nhập. Đang hoàn tất…</string>
-    <string name="ms_device_code_browser_opened">Hoàn tất đăng nhập Microsoft mới trong trình duyệt rồi quay lại đây.</string>
-    <string name="ms_device_code_expires">Mã hết hạn sau %1$d:%2$02d</string>
-    <string name="ms_device_code_copy">Sao chép mã</string>
-    <string name="ms_device_code_copied">Đã sao chép mã</string>
-    <string name="ms_device_code_open_browser">Mở đăng nhập Microsoft</string>
-    <string name="ms_device_code_step_title">Hoàn tất đăng nhập trong trình duyệt</string>
-    <string name="ms_device_code_browser_note">LeviLauncher mở trình duyệt mặc định trong phiên riêng tư, tự động điền mã và yêu cầu đăng nhập Microsoft mới.</string>
-    <string name="ms_choose_other_method">Phương thức khác</string>
-    <string name="ms_no_browser">Không có trình duyệt nào trên thiết bị này.</string>
-    <string name="ms_default_browser_no_private_mode">Trình duyệt mặc định của bạn không hỗ trợ đăng nhập riêng tư. Hãy cập nhật hoặc dùng đăng nhập WebView.</string>
-    <string name="ms_login_ssl_failed">Không thể xác minh trang đăng nhập Microsoft bảo mật.</string>
-    <string name="ms_login_state_failed">Không thể xác minh phản hồi đăng nhập Microsoft. Hãy bắt đầu đăng nhập lại.</string>
-    <string name="ms_login_missing_code">Microsoft không trả về mã đăng nhập. Hãy bắt đầu đăng nhập lại hoặc dùng Mã thiết bị.</string>
-    <string name="ms_feature_disabled_title">Tính năng bị tắt</string>
-    <string name="ms_feature_disabled_desc">Hãy bật “Đăng nhập Minecraft bằng LeviLauncher” trong Cài đặt để quản lý tài khoản Microsoft.</string>
-    <string name="ms_activated">Đã kích hoạt</string>
-    <string name="inbuilt_mod_gyro">Con quay hồi chuyển</string>
-    <string name="inbuilt_mod_gyro_desc">Dùng con quay hồi chuyển của thiết bị để điều khiển xoay camera</string>
-    <string name="inbuilt_mod_pojav_controls">Điều khiển Pojav</string>
-    <string name="inbuilt_mod_pojav_controls_desc">Thay điều khiển cảm ứng Minecraft bằng điều khiển kiểu Pojav có thể tùy chỉnh hoàn toàn</string>
-    <string name="inbuilt_mod_more_buttons">Thêm nút</string>
-    <string name="inbuilt_mod_more_buttons_desc">Tạo các nút tùy chỉnh trên màn hình với ánh xạ một phím và biểu tượng SVG</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">Hiển thị mọi nơi</string>
-    <string name="mod_config_zoom_transition">Thời lượng chuyển đổi (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">Độ nhạy ngang (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">Độ nhạy dọc (%)</string>
-    <string name="mod_config_gyro_invert_x">Đảo trục ngang</string>
-    <string name="mod_config_gyro_invert_y">Đảo trục dọc</string>
-    <string name="mod_config_gyro_deadzone">Vùng chết</string>
+
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">Đóng</string>
     <string name="previous">Trước</string>
     <string name="next">Tiếp theo</string>
@@ -926,6 +1022,8 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="custom_color_hint">#RRGGBB hoặc R,G,B</string>
     <string name="screenshot_name_placeholder">Tên ảnh chụp màn hình</string>
     <string name="screenshot_date_placeholder">Ngày: 2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">Tạo các nút trên màn hình theo phong cách Minecraft, mỗi nút được ánh xạ chính xác tới một phím bàn phím. Các nút không bao giờ chạy macro, chuỗi phím, lặp tự động hoặc tự động nhấp.</string>
     <string name="more_buttons_add_button">Thêm nút</string>
     <string name="more_buttons_limit_reached">Đã đạt giới hạn tối đa %1$d nút tùy chỉnh.</string>
@@ -983,99 +1081,17 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="more_buttons_no_svg_selected">Chưa chọn SVG</string>
     <string name="more_buttons_default_name">Nút</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">Ô thanh nhanh</string>
     <string name="inbuilt_mod_hotbar_slot_desc">Thêm các nút 1–9 riêng để chọn ô trên thanh nhanh</string>
     <string name="hotbar_slot_content_description">Ô thanh nhanh %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">Lối tắt màn hình chính</string>
-    <string name="instance_shortcut_desc">Thay đổi tên và biểu tượng được lưu tự động. Nhấn Thêm lối tắt để tạo hoặc cập nhật lối tắt trên màn hình chính.</string>
-    <string name="instance_shortcut_name">Tên lối tắt</string>
-    <string name="instance_shortcut_icon">Biểu tượng lối tắt</string>
-    <string name="instance_shortcut_choose_icon">Chọn biểu tượng</string>
-    <string name="instance_shortcut_default_icon">Dùng mặc định</string>
-    <string name="instance_shortcut_add_button">Thêm lối tắt</string>
-    <string name="instance_settings_auto_save_failed">Không thể lưu cài đặt phiên bản này.</string>
-    <string name="instance_shortcut_not_supported">Trình khởi chạy màn hình chính của bạn không hỗ trợ lối tắt được ghim.</string>
-    <string name="instance_shortcut_missing">Phiên bản Minecraft này không còn khả dụng.</string>
-    <string name="custom_flat_world_subtitle">Tạo thế giới với quần xã và các lớp khối của riêng bạn</string>
-    <string name="world_settings">Cài đặt thế giới</string>
-    <string name="world_settings_hint">Chọn các cài đặt cơ bản cho thế giới mới</string>
-    <string name="layers_title">Các lớp</string>
-    <string name="add_layer_compact">Thêm lớp</string>
-    <string name="no_layers_title">Chưa có lớp nào</string>
-    <string name="no_layers_hint">Thêm ít nhất một lớp khối để tạo thế giới</string>
-    <string name="reorder_layer">Sắp xếp lại lớp</string>
-    <string name="delete_layer">Xóa lớp</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">Quét</string>
-    <string name="scan_downloads_scanning">Đang quét…</string>
-    <string name="scan_downloads_none_found">Không tìm thấy mod .levipack hoặc .so trong Tải xuống</string>
-    <string name="scan_downloads_failed">Không thể quét thư mục Tải xuống</string>
-    <string name="scan_downloads_permission_denied">Cần quyền truy cập bộ nhớ để quét thư mục Tải xuống</string>
-    <string name="scan_downloads_results_title">Mod trong Tải xuống</string>
-    <string name="scan_downloads_results_subtitle">Chọn mod để thêm. Quét chỉ kiểm tra thư mục Tải xuống chính.</string>
-    <string name="scan_downloads_add">Thêm</string>
-    <string name="scan_downloads_adding">Đang thêm…</string>
-    <string name="scan_downloads_added">Đã thêm</string>
-    <string name="scan_downloads_added_message">Đã thêm %1$s</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">Thư viện native</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">Mod bên ngoài</string>
-    <string name="external_mods_subtitle">Mod cộng đồng cho Minecraft %1$s</string>
-    <string name="external_mods_no_version">Chọn phiên bản Minecraft trước khi cài mod</string>
-    <string name="external_mods_search_hint">Tìm mod, tác giả hoặc phiên bản…</string>
-    <string name="external_mods_compatible_only">Chỉ tương thích</string>
-    <string name="external_mods_all_versions">Tất cả phiên bản Minecraft</string>
-    <string name="external_mods_sort_newest">Mới nhất</string>
-    <string name="external_mods_sort_name">Tên A–Z</string>
-    <string name="external_mods_empty">Không có mod nào khớp với các bộ lọc này</string>
-    <string name="external_mods_load_failed">Không thể làm mới danh mục. Đang hiển thị bản đã lưu.</string>
-    <string name="external_mods_refresh">Làm mới danh mục</string>
-    <string name="external_mods_refreshed">Đã làm mới danh mục</string>
-    <string name="external_mods_join_discord">Tham gia Discord cộng đồng</string>
-    <string name="external_mods_discord_open_failed">Không có ứng dụng nào có thể mở lời mời Discord</string>
-    <string name="external_mods_download">Đang tải %1$s</string>
-    <string name="external_mods_importing">Đang nhập mod…</string>
-    <string name="external_mods_installed">Đã cài %1$s</string>
-    <string name="external_mods_install_failed">Không thể cài %1$s: %2$s</string>
-    <string name="external_mods_open_failed">Không có trình duyệt nào có thể mở bản tải xuống này</string>
-    <string name="external_mods_direct_download">Tải trực tiếp</string>
-    <string name="external_mods_ad_download">Tải có quảng cáo</string>
-    <string name="external_mods_external_link">Liên kết ngoài</string>
-    <string name="external_mods_open_link">Mở liên kết</string>
-    <string name="external_mods_external_dialog_title">Tải xuống bên ngoài</string>
-    <string name="external_mods_ad_dialog_title">Tải xuống có quảng cáo</string>
-    <string name="external_mods_external_dialog_message">%1$s sử dụng trang tải xuống bên ngoài LeviLauncher.\n\n1. Nhấn Mở liên kết và tải tệp .levipack hoặc .so.\n2. Quay lại LeviLauncher và mở Mod.\n3. Nhấn Quét.\n4. Nhấn Thêm bên cạnh mod bạn muốn nhập.\n\nQuét chỉ kiểm tra thư mục Tải xuống chính. Hãy chuyển tệp vào đó nếu trình duyệt đã lưu ở nơi khác.</string>
-    <string name="external_mods_ad_dialog_message">%1$s sử dụng trang tải xuống có quảng cáo do nhà phát triển chọn. LeviLauncher không kiểm soát trang đó hoặc quảng cáo trên đó.\n\n1. Nhấn Mở liên kết và tải tệp .levipack hoặc .so.\n2. Quay lại LeviLauncher và mở Mod.\n3. Nhấn Quét.\n4. Nhấn Thêm bên cạnh mod bạn muốn nhập.\n\nQuét chỉ kiểm tra thư mục Tải xuống chính. Chỉ tải tệp mod; không cài ứng dụng không liên quan hoặc cho phép thông báo.</string>
-    <string name="external_mods_by_author">bởi %1$s</string>
-    <string name="external_mods_version">Mod %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">Cập nhật</string>
-    <string name="external_mods_installed_button">Đã cài</string>
-    <string name="external_mods_incompatible">Không tương thích</string>
-    <string name="foreground_service">Dịch vụ tiền cảnh</string>
-    <string name="foreground_service_desc">Giữ Minecraft tiếp tục chạy khi bạn chuyển ứng dụng bằng cách ngăn Bedrock tạm dừng phiên đang hoạt động và giữ tiến trình, CPU cùng Wi-Fi luôn hoạt động.</string>
-    <string name="foreground_service_warning">Lưu ý: Có thể khiến điện thoại nóng nhanh hơn và tăng mức sử dụng pin.</string>
-    <string name="foreground_service_channel">Bảo vệ Minecraft khi chạy nền</string>
-    <string name="foreground_service_notification_title">Minecraft đang được giữ hoạt động</string>
-    <string name="foreground_service_notification_text">Chế độ nền của Minecraft đang hoạt động. CPU và quyền truy cập mạng được duy trì cho phiên hiện tại.</string>
-    <string name="mod_menu_compact">Menu Mod gọn</string>
-    <string name="mod_menu_compact_desc">Dùng menu nhỏ hơn với danh sách mô-đun dày hơn và bộ lọc gọn</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">Hệ số độ nhạy (100% = 1x)</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">Tốc độ ngang (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">Tốc độ dọc (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">Bộ lọc chuyển động nhỏ (0 = Tắt)</string>
-    <string name="hud_editor_drag_hint">Kéo để di chuyển bảng</string>
-    <string name="hud_editor_drag_description">Trình chỉnh sửa HUD. Kéo khu vực này để di chuyển bảng.</string>
     <string name="mod_config_hotbar_item_icons">Dùng biểu tượng vật phẩm từ thanh nhanh</string>
     <string name="mod_config_hotbar_item_counts">Hiển thị số lượng vật phẩm</string>
     <string name="mod_config_hotbar_slot_enabled">Hiển thị ô thanh nhanh %1$d</string>
     <string name="mod_config_hotbar_slot_size">Kích thước ô thanh nhanh %1$d (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Độ mờ ô thanh nhanh %1$d</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">Có gì mới</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Tiếp tục</string>
@@ -1098,6 +1114,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="mod_config_category_button">Nút</string>
     <string name="mod_config_visible_slots">Ô hiển thị</string>
     <string name="mod_config_hotbar_slot_section">Ô thanh nhanh %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">Chọn</string>
     <string name="select_all">Chọn tất cả</string>
     <string name="selected">Đã chọn</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">Để cài đặt hoặc cập nhật ứng dụng này, vui lòng cấp quyền cài đặt ứng dụng không rõ nguồn gốc. Nhấp vào "Cấp quyền" để mở cài đặt hệ thống, bật quyền cho ứng dụng này và quay lại để tiếp tục.</string>
 
     <string name="check_update">Kiểm tra cập nhật</string>
-    <string name="version_prefix">Phiên bản:</string>
+    <string name="version_prefix">Phiên bản: </string>
     <string name="unknown_error">Lỗi không xác định</string>
     <string name="preloader_sigs_title">Dữ liệu thời gian chạy</string>
     <string name="preloader_sigs_last_update">Cập nhật lần cuối: %1$s</string>
@@ -452,7 +452,7 @@ Quá trình chuyển đổi phải hoàn tất trước khi LeviLauncher có th�
     <string name="genuine_badge_label">Giấy phép chưa được xác minh</string>
     <string name="invalid_license_detected_toast">Đã phát hiện Minecraft không phải bản chính hãng. Hãy đảm bảo Minecraft của bạn được tải từ Google Play Store.</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Tổng các Mods:</string>
     <string name="enabled_mods">Đã bật:</string>
     <string name="add_mod">Thêm Mod</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,8 +1,21 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
     <string name="minecraft">Minecraft</string>
     <string name="launch">启动</string>
+    <string name="beta_badge">Beta</string>
+    <string name="debug_badge">Debug</string>
+    <string name="cursor">光标</string>
+    <string name="bedrock_edition">基岩版</string>
+    <string name="current_instance">当前实例</string>
 
     <!-- Mods -->
     <string name="mods_title">模组 (%d)</string>
@@ -19,13 +32,15 @@
     <string name="about_title">☕ 关于</string>
     <string name="copyright">©2024–2026 LeviMC. 保留所有权利</string>
     <string name="font_license">本软件使用 Misans 字体</string>
+    <string name="about_footer_github">GitHub: https://github.com/LiteLDev/LeviLaunchroid</string>
     <string name="quick_actions_title">快捷操作</string>
+    <string name="content_mgmt_section_title">内容管理</string>
+    <string name="misc_section_title">其他</string>
+    <string name="view_all">查看全部 →</string>
     <string name="content_management_subtitle">管理世界、资源包和行为包</string>
     <string name="import_apk_subtitle">从 APK 或 APKS 文件安装 Minecraft</string>
     <string name="ms_add_account">添加账号</string>
     <string name="ms_add_account_subtitle">使用 Microsoft 登录</string>
-    <string name="microsoft_accounts">Microsoft 账号</string>
-    <string name="manage_accounts">管理</string>
 
     <!-- Dialogs -->
     <string name="content_detected_title">检测到内容导入</string>
@@ -36,6 +51,11 @@
 
     <string name="import_confirmation_title">导入模组</string>
     <string name="import_confirmation_message">确定要导入所选的 %d 个模组文件吗？</string>
+    <string name="import_so_plugin_title">导入 SO 插件</string>
+    <string name="plugin_name_label">插件名称</string>
+    <string name="plugin_type_label">类型</string>
+    <string name="plugin_version_label">版本</string>
+    <string name="import_button">导入</string>
     <string name="overwrite_file_title">文件已存在</string>
     <string name="overwrite_file_message">文件 %s 已存在，是否覆盖？</string>
     <string name="overwrite">覆盖</string>
@@ -45,18 +65,6 @@
 
     <string name="installed_packages">已安装包</string>
     <string name="local_custom">本地自定义</string>
-
-    <string name="check_update">检查更新</string>
-    <string name="version_prefix">版本号：</string>
-    <string name="unknown_error">未知错误</string>
-    <string name="preloader_sigs_title">运行时数据</string>
-    <string name="preloader_sigs_last_update">上次更新：%1$s</string>
-    <string name="preloader_sigs_never_updated">从未更新</string>
-    <string name="preloader_sigs_update">更新运行时数据</string>
-    <string name="preloader_sigs_updating">正在更新…</string>
-    <string name="preloader_sigs_update_success">运行时数据已更新</string>
-    <string name="preloader_sigs_update_failed">运行时数据更新失败：%1$s</string>
-    <string name="preloader_sigs_no_remote_url">未配置运行时数据更新地址</string>
 
     <!-- Permissions -->
     <string name="storage_permission_title">存储迁移权限</string>
@@ -95,9 +103,46 @@
 
     <string name="settings_title">设置</string>
     <string name="settings_desc">您的启动器设置</string>
+    <string name="settings_subtitle">配置常用启动器选项</string>
+    <string name="settings_tab_basic">基础设置</string>
+    <string name="settings_tab_personalize">个性化</string>
+    <string name="settings_tab_updates">更新</string>
+    <string name="settings_tab_about">关于</string>
+    <string name="settings_tab_migration">迁移</string>
+    <string name="settings_theme_desc">选择应用主题</string>
+
 
     <string name="unknown_sources_permission_title">安装权限</string>
     <string name="unknown_sources_permission_message">请授予安装未知来源应用的权限，否则无法完成应用更新/安装。点击“授权”前往系统设置开启后返回本应用继续操作。</string>
+
+    <string name="check_update">检查更新</string>
+    <string name="version_prefix">版本号：</string>
+    <string name="unknown_error">未知错误</string>
+    <string name="preloader_sigs_title">运行时数据</string>
+    <string name="preloader_sigs_last_update">上次更新：%1$s</string>
+    <string name="preloader_sigs_never_updated">从未更新</string>
+    <string name="preloader_sigs_update">更新运行时数据</string>
+    <string name="preloader_sigs_updating">正在更新…</string>
+    <string name="preloader_sigs_update_success">运行时数据已更新</string>
+    <string name="preloader_sigs_update_failed">运行时数据更新失败：%1$s</string>
+    <string name="preloader_sigs_no_remote_url">未配置运行时数据更新地址</string>
+
+    <string name="dialog_title_no_version">未选择版本</string>
+    <string name="dialog_message_no_version">请在启动前选择游戏版本。</string>
+    <string name="dialog_title_version_isolation">需要版本隔离</string>
+    <string name="dialog_message_version_isolation">这是一个导入的版本。请在设置中启用版本隔离以启动此版本。</string>
+    <string name="dialog_positive_enable">启用</string>
+    <string name="dialog_title_launch_failed">启动失败</string>
+    <string name="dialog_message_launch_failed">无法启动Minecraft：%1$s</string>
+    <string name="dialog_title_incompatible_mods">已跳过不兼容模组</string>
+    <string name="dialog_message_incompatible_mods">部分已启用模组与当前 Minecraft 版本 %1$s 不兼容，已跳过加载：\n\n%2$s</string>
+    <string name="dialog_title_disable_version_isolation">禁用版本隔离</string>
+    <string name="dialog_message_disable_version_isolation">您尝试在启用版本隔离的情况下启动已安装的版本。请禁用版本隔离以继续。</string>
+    <string name="dialog_positive_disable">禁用</string>
+    <string name="dialog_positive_ok">确定</string>
+    <string name="delete_account_title">删除账户</string>
+    <string name="delete_account_confirm">确定要删除此账户吗？</string>
+
 
     <string name="new_version_found">发现新版本：%1$s</string>
     <string name="update_question">是否下载并安装最新版本？</string>
@@ -125,6 +170,7 @@
     <string name="repair_preparing">准备中…</string>
     <string name="repair_processing">正在提取库文件…</string>
     <string name="repair_finalizing">正在完成修复…</string>
+    <!-- Storage Migration -->
     <string name="storage_migration_title">需要迁移存储目录</string>
     <string name="storage_migration_message">LeviLauncher 必须先将数据从 games/org.levimc 迁移到 %1$s，才能继续使用。
 
@@ -169,36 +215,21 @@
     <string name="shared_storage_layout_mode_legacy">原始内部/外部目录</string>
     <string name="shared_storage_layout_status">当前模式：%1$s\n内部：%2$s\n外部：%3$s</string>
     <string name="shared_storage_layout_changed">存储目录选择已更新。请重启 Minecraft 并重新打开内容管理，以确保变更完全生效。</string>
-    
+    <!-- Theme -->
     <string name="theme_title">主题模式</string>
     <string name="theme_follow_system">跟随系统</string>
     <string name="theme_light">强制白天</string>
     <string name="theme_dark">强制夜间</string>
 
     <string name="error_no_browser">无法打开浏览器</string>
-
-    <string name="dialog_title_no_version">未选择版本</string>
-    <string name="dialog_message_no_version">请在启动前选择游戏版本。</string>
-    <string name="dialog_title_version_isolation">需要版本隔离</string>
-    <string name="dialog_message_version_isolation">这是一个导入的版本。请在设置中启用版本隔离以启动此版本。</string>
-    <string name="dialog_positive_enable">启用</string>
-    <string name="dialog_title_launch_failed">启动失败</string>
-    <string name="dialog_message_launch_failed">无法启动Minecraft：%1$s</string>
-    <string name="dialog_title_incompatible_mods">已跳过不兼容模组</string>
-    <string name="dialog_message_incompatible_mods">部分已启用模组与当前 Minecraft 版本 %1$s 不兼容，已跳过加载：\n\n%2$s</string>
-    <string name="dialog_title_disable_version_isolation">禁用版本隔离</string>
-    <string name="dialog_message_disable_version_isolation">您尝试在启用版本隔离的情况下启动已安装的版本。请禁用版本隔离以继续。</string>
-    <string name="dialog_positive_disable">禁用</string>
-    <string name="dialog_positive_ok">确定</string>
-
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher 用户协议</string>
     <string name="eula_message"><b>欢迎使用 LeviLauncher</b>\n\n使用本软件即表示您同意：\n\n• 此为<b>非官方</b> Minecraft 启动器\n• 您需拥有<b>合法授权</b>的 Minecraft 副本\n• 禁止任何形式的盗版或作弊行为\n• 模组/资源包使用风险自负\n• 与 Mojang/Microsoft 无关联\n\n继续使用视为接受条款</string>
     <string name="eula_agree">接受</string>
     <string name="eula_exit">拒绝</string>
 
     <string name="allow_unknown_sources">请允许安装未知来源应用再操作</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">删除版本</string>
     <string name="dialog_message_delete_version">确定要删除此自定义版本？删除后不可恢复。</string>
     <string name="dialog_positive_delete">删除</string>
@@ -216,7 +247,68 @@
     <string name="dialog_message_delete_mod">确定要删除该 Mod 吗？</string>
 
     <string name="version_isolation">版本隔离</string>
+    <string name="launch_vertically">竖屏启动</string>
+    <string name="launch_vertically_desc">强制游戏以竖屏模式启动</string>
+    <!-- Instance Management -->
+    <string name="instance_settings_title">实例设置</string>
+    <string name="instance_tab_general">常规</string>
+    <string name="instance_tab_launch_options">启动选项</string>
+    <string name="instance_tab_management">管理</string>
+    <string name="instance_new_name">新名称</string>
+    <string name="instance_rename_hint">仅重命名文件夹。游戏版本和类型不受影响。</string>
+    <string name="instance_custom_icon">自定义图标（需为正方形）</string>
+    <string name="instance_clear_icon">清除</string>
+    <string name="instance_icon_hint">将保存为版本文件夹下的 LargeLogo.png。点击图标进行更改。</string>
+    <string name="instance_isolation_desc">为此实例隔离游戏数据。其他实例不会受到影响。</string>
+    <string name="instance_shortcut_title">主屏幕快捷方式</string>
+    <string name="instance_shortcut_desc">名称和图标的更改会自动保存。点击“添加快捷方式”以创建或更新主屏幕快捷方式。</string>
+    <string name="instance_shortcut_name">快捷方式名称</string>
+    <string name="instance_shortcut_icon">快捷方式图标</string>
+    <string name="instance_shortcut_choose_icon">选择图标</string>
+    <string name="instance_shortcut_default_icon">使用默认图标</string>
+    <string name="instance_shortcut_add_button">添加快捷方式</string>
+    <string name="instance_settings_auto_save_failed">无法保存此实例设置。</string>
+    <string name="instance_shortcut_not_supported">您的主屏幕启动器不支持固定快捷方式。</string>
+    <string name="instance_shortcut_missing">此 Minecraft 实例已不可用。</string>
+    <string name="instance_danger_zone">危险区域</string>
+    <string name="instance_danger_zone_desc">这些操作会影响实例注册信息或本地文件。继续前请仔细确认。</string>
+    <string name="instance_delete_desc">从设备中永久删除此实例，包括世界、配置和已安装内容。</string>
+    <string name="instance_delete_warning">此操作无法撤销。</string>
+    <string name="instance_delete_confirm_title">删除实例</string>
+    <string name="instance_delete_confirm_msg">确定要删除此实例吗？包括世界在内的所有数据都将被永久移除。</string>
+    <string name="instance_backup_title">备份实例</string>
+    <string name="instance_backup_desc">将此实例完整备份到 Download/LeviLauncher/Backups。</string>
+    <string name="instance_backup_button">备份实例</string>
+    <string name="instance_backup_confirm_message">现在创建此实例的完整备份吗？如果 Minecraft 正在运行，建议先退出游戏，避免备份过程中数据变化。</string>
+    <string name="instance_backup_in_progress">正在备份实例…</string>
+    <string name="instance_backup_success_title">备份已创建</string>
+    <string name="instance_backup_success_message">备份已保存到：\n%1$s</string>
+    <string name="instance_backup_failed_title">备份失败</string>
+    <string name="instance_backup_failed_message">无法创建备份：\n%1$s</string>
+    <string name="instance_import_backup_button">导入备份</string>
+    <string name="instance_batch_backup_button">批量备份</string>
+    <string name="instance_batch_backup_title">批量备份实例</string>
+    <string name="instance_batch_backup_select_message">选择需要备份的实例。如果 Minecraft 正在运行，建议先退出游戏，避免备份过程中数据变化。</string>
+    <string name="instance_batch_backup_select_all">选择全部实例</string>
+    <string name="instance_batch_backup_no_instances">当前没有可备份的实例。</string>
+    <string name="instance_batch_backup_no_selection">请至少选择一个实例。</string>
+    <string name="instance_batch_backup_in_progress">正在备份 %1$s（%2$d/%3$d）…</string>
+    <string name="instance_batch_backup_success_title">备份已创建</string>
+    <string name="instance_batch_backup_success_message">已创建 %1$d 个备份：\n%2$s</string>
+    <string name="instance_batch_backup_partial_title">部分备份完成</string>
+    <string name="instance_batch_backup_partial_message">已创建 %1$d 个备份，%2$d 个失败。\n\n已保存：\n%3$s\n\n失败：\n%4$s</string>
+    <string name="instance_batch_backup_failed_title">批量备份失败</string>
+    <string name="instance_batch_backup_failed_message">未能创建任何备份：\n%1$s</string>
+    <string name="instance_restore_title">恢复备份</string>
+    <string name="instance_restore_in_progress">正在恢复实例备份…</string>
+    <string name="instance_restore_success_title">恢复完成</string>
+    <string name="instance_restore_success_message">已恢复：%1$s</string>
+    <string name="instance_restore_failed_title">恢复失败</string>
+    <string name="instance_restore_failed_message">无法恢复备份：\n%1$s</string>
+
     <!-- Language Setting -->
+    <!-- Keep English at the top (default language). -->
+    <!-- Sort all other languages alphabetically by their display name. -->
     <string name="language">语言 (Language)</string>
     <string name="english">英语 (English)</string>
     <string name="chinese">简体中文 (Chinese)</string>
@@ -230,7 +322,7 @@
     <string name="turkish">Türkçe (Turkish)</string>
     <string name="vietnamese">Tiếng Việt (Vietnamese)</string>
 
-    <!-- 版本重命名 -->
+    <!-- Version Rename -->
     <string name="rename_version_title">重命名版本</string>
     <string name="rename_version_message">为此版本输入一个新名称：</string>
     <string name="new_version_name">新版本名称</string>
@@ -244,6 +336,13 @@
     <string name="worlds_title">世界</string>
     <string name="resource_packs_title">资源包</string>
     <string name="behavior_packs_title">行为包</string>
+    <string name="skin_packs_title">皮肤包</string>
+    <string name="worlds_category">世界</string>
+    <string name="resource_packs_category">资源包</string>
+    <string name="behavior_packs_category">行为包</string>
+    <string name="skin_packs_category">皮肤包</string>
+    <string name="screenshots_category">截图</string>
+    <string name="servers_category">服务器</string>
     <string name="storage_internal">内部</string>
     <string name="storage_external">外部</string>
     <string name="storage_version_isolation">版本隔离</string>
@@ -279,8 +378,8 @@
     <!-- Resource Pack Management -->
     <string name="import_resource_pack">导入资源包</string>
     <string name="import_behavior_pack">导入行为包</string>
-    <string name="delete_resource_pack">删除资源包</string>
     <string name="import_skin_pack">导入皮肤包</string>
+    <string name="delete_resource_pack">删除资源包</string>
     <string name="delete_skin_pack">删除皮肤包</string>
     <string name="delete_behavior_pack">删除行为包</string>
 
@@ -304,6 +403,7 @@
     <string name="edit">编辑</string>
     <string name="save">保存</string>
     <string name="reset">重置</string>
+    <string name="saved_to_gallery">已保存到相册</string>
     <string name="level_dat_not_found">未找到 level.dat</string>
     <string name="no_editable_properties">未找到可编辑属性</string>
     <string name="no_data">无数据</string>
@@ -327,6 +427,20 @@
     <string name="add_at_least_one_layer">请至少添加一层</string>
     <string name="world_created_successfully">世界创建成功</string>
     <string name="failed_to_create_world">创建世界失败</string>
+    <string name="custom_flat_world_subtitle">使用自定义生物群系和方块层创建世界</string>
+    <string name="world_settings">世界设置</string>
+    <string name="world_settings_hint">选择新世界的基本设置</string>
+    <string name="layers_title">层</string>
+    <string name="add_layer_compact">添加层</string>
+    <string name="no_layers_title">还没有层</string>
+    <string name="no_layers_hint">至少添加一层方块才能创建世界</string>
+    <string name="reorder_layer">重新排序此层</string>
+    <string name="delete_layer">删除此层</string>
+    <string name="block_id_hint">minecraft:stone</string>
+    <plurals name="flat_layers_count">
+        <item quantity="one">%1$d 层 • 底部 → 顶部</item>
+        <item quantity="other">%1$d 层 • 底部 → 顶部</item>
+    </plurals>
 
     <!-- Play Store Validation -->
     <string name="minecraft_playstore_required_title">需要 Play 商店版本</string>
@@ -338,11 +452,57 @@
     <string name="genuine_badge_label">未通过正版验证</string>
     <string name="invalid_license_detected_toast">非正版MC，请确保设备上MC来自于谷歌商店</string>
 
-
-    <string name="full_mods_title">模组 </string>
+    <string name="full_mods_title">模组</string>
     <string name="total_mods">模组总数：</string>
     <string name="enabled_mods">已启用：</string>
     <string name="add_mod">添加模组</string>
+    <string name="scan_downloads">扫描</string>
+    <string name="scan_downloads_scanning">正在扫描…</string>
+    <string name="scan_downloads_none_found">下载文件夹中未找到 .levipack 或 .so 模组</string>
+    <string name="scan_downloads_failed">无法扫描下载文件夹</string>
+    <string name="scan_downloads_permission_denied">扫描下载文件夹需要存储访问权限</string>
+    <string name="scan_downloads_results_title">下载文件夹中的模组</string>
+    <string name="scan_downloads_results_subtitle">选择要添加的模组。扫描仅检查主下载文件夹。</string>
+    <string name="scan_downloads_add">添加</string>
+    <string name="scan_downloads_adding">正在添加…</string>
+    <string name="scan_downloads_added">已添加</string>
+    <string name="scan_downloads_added_message">已添加 %1$s</string>
+    <string name="scan_downloads_levipack">LeviPack</string>
+    <string name="scan_downloads_native_library">原生库</string>
+    <string name="scan_downloads_file_details">%1$s • %2$s</string>
+    <string name="external_mods">外部模组</string>
+    <string name="external_mods_subtitle">适用于 Minecraft %1$s 的社区模组</string>
+    <string name="external_mods_no_version">安装模组前请选择 Minecraft 版本</string>
+    <string name="external_mods_search_hint">搜索模组、作者或版本…</string>
+    <string name="external_mods_compatible_only">仅显示兼容项</string>
+    <string name="external_mods_all_versions">所有 Minecraft 版本</string>
+    <string name="external_mods_sort_newest">最新</string>
+    <string name="external_mods_sort_name">名称 A–Z</string>
+    <string name="external_mods_empty">没有符合这些筛选条件的模组</string>
+    <string name="external_mods_load_failed">无法刷新目录。正在显示已保存的副本。</string>
+    <string name="external_mods_refresh">刷新目录</string>
+    <string name="external_mods_refreshed">目录已刷新</string>
+    <string name="external_mods_join_discord">加入社区 Discord</string>
+    <string name="external_mods_discord_open_failed">没有应用可以打开 Discord 邀请</string>
+    <string name="external_mods_download">正在下载 %1$s</string>
+    <string name="external_mods_importing">正在导入模组…</string>
+    <string name="external_mods_installed">已安装 %1$s</string>
+    <string name="external_mods_install_failed">无法安装 %1$s：%2$s</string>
+    <string name="external_mods_open_failed">没有浏览器可以打开此下载</string>
+    <string name="external_mods_direct_download">直接下载</string>
+    <string name="external_mods_ad_download">广告下载</string>
+    <string name="external_mods_external_link">外部链接</string>
+    <string name="external_mods_open_link">打开链接</string>
+    <string name="external_mods_external_dialog_title">外部下载</string>
+    <string name="external_mods_ad_dialog_title">广告支持的下载</string>
+    <string name="external_mods_external_dialog_message">%1$s 使用 LeviLauncher 之外的下载页面。\n\n1. 点击“打开链接”并下载 .levipack 或 .so 文件。\n2. 返回 LeviLauncher 并打开“模组”。\n3. 点击“扫描”。\n4. 点击要导入的模组旁边的“添加”。\n\n扫描仅检查主下载文件夹。如果浏览器将文件保存到了其他位置，请将文件移动到该文件夹。</string>
+    <string name="external_mods_ad_dialog_message">%1$s 使用由其开发者选择的广告支持下载页面。LeviLauncher 不控制该页面或其中的广告。\n\n1. 点击“打开链接”并下载 .levipack 或 .so 文件。\n2. 返回 LeviLauncher 并打开“模组”。\n3. 点击“扫描”。\n4. 点击要导入的模组旁边的“添加”。\n\n扫描仅检查主下载文件夹。只下载模组文件；不要安装无关应用，也不要允许通知。</string>
+    <string name="external_mods_by_author">作者：%1$s</string>
+    <string name="external_mods_version">模组 %1$s</string>
+    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
+    <string name="external_mods_update">更新</string>
+    <string name="external_mods_installed_button">已安装</string>
+    <string name="external_mods_incompatible">不兼容</string>
 
     <!-- Mod Detail -->
     <string name="mod_detail_title">模组详情</string>
@@ -390,22 +550,25 @@
     <string name="mod_config_error_maximum">%1$s 不能大于 %2$s</string>
     <string name="mod_config_error_boolean">%1$s 必须是开关值</string>
     <string name="mod_config_error_string">%1$s 必须是文本</string>
-
+    <!-- Mod Configuration -->
     <plurals name="mod_config_files_count">
+        <item quantity="one">%d 个可编辑配置</item>
         <item quantity="other">%d 个可编辑配置</item>
     </plurals>
     <plurals name="mod_config_choices_count">
+        <item quantity="one">%d 个选项</item>
         <item quantity="other">%d 个选项</item>
     </plurals>
     <plurals name="mod_config_items_count">
+        <item quantity="one">%d 项</item>
         <item quantity="other">%d 项</item>
     </plurals>
 
-    <!-- 版本选择对话框 -->
+    <!-- Game Version Select Dialog -->
     <string name="game_version_select_title">选择游戏版本</string>
     <string name="back">返回</string>
-    
-    <!-- 启动页 -->
+
+    <!-- Splash -->
     <string name="splash_logo_desc">叶子标志</string>
     <string name="minecraft_loading_title">正在启动 Minecraft</string>
     <string name="minecraft_loading_subtitle">准备游戏文件与已启用模组</string>
@@ -419,42 +582,82 @@
     <string name="launcher_restart_subtitle">请稍等，马上回到主页面</string>
     <string name="launcher_restart_status">马上就好…</string>
 
-    <!-- 账户管理 -->
+    <!-- Accounts & Microsoft Login -->
     <string name="accounts_title">账号</string>
+    <string name="microsoft_accounts">Microsoft 账号</string>
+    <string name="manage_accounts">管理</string>
     <string name="not_signed_in">未登录</string>
     <string name="xuid">XUID</string>
+    <string name="sign_in">登录</string>
     <string name="sign_out">退出登录</string>
     <string name="accounts_active_privilege">已登录</string>
+
     <string name="ms_login_title">Microsoft 登录</string>
-    <string name="ms_login_success">已登录为 %1$s</string>
-    <string name="ms_set_active">设为当前</string>
-    <string name="ms_delete">删除</string>
-    <string name="ms_active_badge">当前</string>
+    <string name="ms_login_header_subtitle">安全登录 Minecraft</string>
     <string name="ms_login_starting">开始 Microsoft 登录…</string>
     <string name="ms_login_exchanging">正在交换令牌…</string>
     <string name="ms_login_auth_xbox_device">正在认证 Xbox 设备…</string>
     <string name="ms_login_fetch_minecraft_identity">正在获取 Minecraft 身份…</string>
+    <string name="ms_login_retrying">连接中断。正在安全重试…</string>
+    <string name="ms_login_success">已登录为 %1$s</string>
     <string name="ms_login_failed">Microsoft 登录失败</string>
     <string name="ms_login_failed_detail">登录失败：%1$s</string>
+    <string name="ms_choose_login_method">登录 Minecraft</string>
+    <string name="ms_choose_login_method_desc">选择基于浏览器的设备代码流程，或继续使用内嵌 Microsoft 页面。</string>
+    <string name="ms_device_code_login">使用浏览器继续</string>
+    <string name="ms_device_code_option_title">设备代码（推荐）</string>
+    <string name="ms_device_code_login_desc">打开一个已自动填入设备代码的私密浏览器会话。</string>
+    <string name="ms_webview_login">打开内嵌登录</string>
+    <string name="ms_webview_option_title">内嵌 WebView</string>
+    <string name="ms_webview_login_desc">无需离开 LeviLauncher 即可登录。当浏览器流程不可用时使用此方式。</string>
+    <string name="ms_device_code_title">使用设备代码登录</string>
+    <string name="ms_device_code_instructions">打开 Microsoft 设备登录页面，输入此代码，然后批准访问。LeviLauncher 会自动完成后续操作。</string>
+    <string name="ms_device_code_label">Microsoft 设备代码</string>
+    <string name="ms_device_code_requesting">正在请求安全代码…</string>
+    <string name="ms_device_code_waiting_code">--------</string>
+    <string name="ms_device_code_waiting">正在等待你在浏览器中完成操作…</string>
+    <string name="ms_device_code_checking">正在检查 Microsoft 登录结果…</string>
+    <string name="ms_device_code_reconnecting">连接已变化。正在自动重试…</string>
+    <string name="ms_device_code_authorized">Microsoft 已批准登录。正在完成…</string>
+    <string name="ms_device_code_browser_opened">请在浏览器中完成新的 Microsoft 登录，然后返回此处。</string>
+    <string name="ms_device_code_expires">代码将在 %1$d:%2$02d 后过期</string>
+    <string name="ms_device_code_copy">复制代码</string>
+    <string name="ms_device_code_copied">代码已复制</string>
+    <string name="ms_device_code_open_browser">打开 Microsoft 登录</string>
+    <string name="ms_device_code_step_title">在浏览器中完成登录</string>
+    <string name="ms_device_code_browser_note">LeviLauncher 会在私密会话中打开默认浏览器，自动填写代码，并请求一次新的 Microsoft 登录。</string>
+    <string name="ms_choose_other_method">其他方式</string>
+    <string name="ms_no_browser">此设备上没有可用的浏览器。</string>
+    <string name="ms_default_browser_no_private_mode">默认浏览器不支持私密登录。请更新浏览器或使用 WebView 登录。</string>
+    <string name="ms_login_ssl_failed">无法验证安全的 Microsoft 登录页面。</string>
+    <string name="ms_login_state_failed">无法验证 Microsoft 登录响应。请重新开始登录。</string>
+    <string name="ms_login_missing_code">Microsoft 未返回登录代码。请重新开始登录或使用设备代码登录。</string>
+
+    <string name="ms_set_active">设为当前</string>
+    <string name="ms_delete">删除</string>
+    <string name="ms_active_badge">当前</string>
+    <string name="ms_account_subtitle_format">用户ID：%1$s • 更新：%2$s</string>
     <string name="xbox_avatar">Xbox头像</string>
     <string name="launcher_managed_mc_login">使用 LeviLauncher 登录 Minecraft</string>
     <string name="dialog_title_login_required">需要登录</string>
     <string name="dialog_message_login_required">已开启使用启动器登录，但当前未登录。请前往账号管理登录后再启动。</string>
     <string name="go_to_accounts">账号管理</string>
     <string name="disable_launcher_login_and_continue">关闭</string>
-    <string name="sign_in">登录</string>
-    <string name="ms_account_subtitle_format">用户ID：%1$s • 更新：%2$s</string>
-    <string name="about_footer_github">GitHub: https://github.com/LiteLDev/LeviLaunchroid</string>
 
+    <string name="ms_feature_disabled_title">功能已禁用</string>
+    <string name="ms_feature_disabled_desc">请在设置中启用“使用 LeviLauncher 登录 Minecraft”，以管理 Microsoft 账户。</string>
+    <string name="ms_activated">已激活</string>
+
+    <!-- Popup labels -->
     <string name="label_current_account">当前账号</string>
     <string name="label_other_accounts">其他账号</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">应用发生崩溃</string>
     <string name="crash_upload">上传崩溃报告</string>
     <string name="crash_details_title">崩溃详情</string>
     <string name="crash_back_to_main">返回主页面</string>
-    <string name="crash_log_file_label">日志文件：</string>
     <string name="crash_share_log">分享日志</string>
+    <string name="crash_log_file_label">日志文件：</string>
     <string name="crash_log_file_missing">日志文件不存在或不可读。</string>
     <string name="crash_read_failed">读取日志失败：%1$s</string>
     <string name="crash_loading_details">正在加载崩溃详情...</string>
@@ -463,25 +666,29 @@
     <string name="crash_stack_label">崩溃详情和堆栈：</string>
     <string name="crash_emergency_label">紧急信息：</string>
     <string name="crash_no_details">未获取到崩溃详情。</string>
-     <string name="dialog_title_exit_app">退出应用</string>
-     <string name="dialog_message_exit_app">确定要退出应用吗？</string>
-     <string name="dialog_positive_exit">退出</string>
-
-     <!-- Logcat Overlay i18n additions -->
-     <string name="show_logcat_overlay">显示日志悬浮窗</string>
+    <string name="dialog_title_exit_app">退出应用</string>
+    <string name="dialog_message_exit_app">确定要退出应用吗？</string>
+    <string name="dialog_positive_exit">退出</string>
+    <string name="show_logcat_overlay">显示日志悬浮窗</string>
+    <string name="foreground_service">前台服务</string>
+    <string name="foreground_service_desc">切换应用时阻止 Bedrock 暂停当前会话，并保持进程、CPU 和 Wi-Fi 活跃，从而让 Minecraft 继续运行。</string>
+    <string name="foreground_service_warning">注意：可能会让手机更快发热并增加电池消耗。</string>
+    <string name="foreground_service_channel">Minecraft 后台保护</string>
+    <string name="foreground_service_notification_title">正在保持 Minecraft 活跃</string>
+    <string name="foreground_service_notification_text">Minecraft 后台模式已启用。当前会话会持续保持 CPU 和网络访问可用。</string>
     <string name="logcat_live">Logcat：<b>实时</b></string>
-     <string name="logcat_paused">Logcat：已暂停</string>
-
-     <string name="logcat_filter_hint">关键字筛选</string>
-     <string name="logcat_blacklist_hint">黑名单（逗号分隔）</string>
-     <string name="logcat_filter_clear">清除筛选</string>
-     <string name="logcat_filter">筛选</string>
-     <string name="logcat_autoscroll">自动滚动</string>
-     <string name="logcat_pause">暂停</string>
-     <string name="logcat_clear">清空</string>
-     <string name="logcat_close">关闭</string>
-     <string name="logcat_corner_bottom_left">调整大小：左下角</string>
-     <string name="logcat_corner_bottom_right">调整大小：右下角</string>
+    <string name="logcat_paused">Logcat：已暂停</string>
+    <!-- Logcat Overlay i18n -->
+    <string name="logcat_filter_hint">关键字筛选</string>
+    <string name="logcat_blacklist_hint">黑名单（逗号分隔）</string>
+    <string name="logcat_filter_clear">清除筛选</string>
+    <string name="logcat_filter">筛选</string>
+    <string name="logcat_autoscroll">自动滚动</string>
+    <string name="logcat_pause">暂停</string>
+    <string name="logcat_clear">清空</string>
+    <string name="logcat_close">关闭</string>
+    <string name="logcat_corner_bottom_left">调整大小：左下角</string>
+    <string name="logcat_corner_bottom_right">调整大小：右下角</string>
 
     <!-- Inbuilt Mods -->
     <string name="inbuilt_mods">内置模组</string>
@@ -492,7 +699,7 @@
     <string name="inbuilt_mod_removed">%s 已从模组移除</string>
     <string name="add">添加</string>
     <string name="remove">移除</string>
-
+    
     <!-- Inbuilt Mods -->
     <string name="inbuilt_mod_quick_drop">快速丢弃</string>
     <string name="inbuilt_mod_quick_drop_desc">快速丢弃物品</string>
@@ -516,6 +723,17 @@
     <string name="inbuilt_mod_cps_display_desc">显示每秒点击次数</string>
     <string name="inbuilt_mod_snaplook">快速回头</string>
     <string name="inbuilt_mod_snaplook_desc">按住快速查看身后（第三人称正面视角）</string>
+    <string name="inbuilt_mod_virtual_cursor">虚拟光标</string>
+    <string name="inbuilt_mod_virtual_cursor_desc">使用虚拟触控板控制鼠标</string>
+    <string name="virtual_cursor_enabled">光标已启用</string>
+    <string name="virtual_cursor_disabled">光标已禁用</string>
+    <string name="cursor_sensitivity_label">光标灵敏度：</string>
+    <string name="inbuilt_mod_gyro">陀螺仪</string>
+    <string name="inbuilt_mod_gyro_desc">使用设备陀螺仪控制摄像机旋转</string>
+    <string name="inbuilt_mod_pojav_controls">Pojav 控制</string>
+    <string name="inbuilt_mod_pojav_controls_desc">用完全可自定义的 Pojav 风格控制替换 Minecraft 触摸控制</string>
+    <string name="inbuilt_mod_more_buttons">更多按钮</string>
+    <string name="inbuilt_mod_more_buttons_desc">使用单键映射和 SVG 图标创建自定义屏幕按钮</string>
     <string name="inbuilt_badge">内置</string>
     <string name="autosprint_keybind_label">自动疾跑按键绑定：</string>
     <string name="autosprint_keybind_press">请按任意键…</string>
@@ -570,6 +788,8 @@
     <string name="mod_menu_notifications_desc">启用模组时显示通知</string>
     <string name="mod_menu_opacity">模组菜单不透明度</string>
     <string name="mod_menu_button_opacity">模组菜单按钮不透明度</string>
+    <string name="mod_menu_compact">紧凑模组菜单</string>
+    <string name="mod_menu_compact_desc">使用更小的菜单、密集的模块列表和紧凑的筛选器</string>
     <string name="mod_menu_version">v1.0</string>
     <string name="mod_menu_enabled">模组菜单已启用</string>
     <string name="mod_menu_disabled">模组菜单已禁用</string>
@@ -583,10 +803,21 @@
     <string name="mod_overlay_cps_value">CPS：%1$d</string>
     <string name="mod_config_overlay_button_size_dp">悬浮按钮大小（dp）</string>
     <string name="mod_config_overlay_opacity_percent" formatted="false">悬浮窗透明度（%）</string>
+    <string name="mod_config_overlay_show_everywhere" formatted="false">始终显示</string>
     <string name="mod_config_cursor_sensitivity_percent" formatted="false">光标灵敏度（%）</string>
     <string name="mod_config_zoom_level_percent" formatted="false">缩放级别（%）</string>
     <string name="mod_config_auto_sprint_keybind">自动疾跑按键绑定</string>
     <string name="mod_config_zoom_keybind">缩放按键绑定</string>
+    <string name="mod_config_zoom_transition">过渡时长 (ms)</string>
+    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">灵敏度倍数（100% = 1x）</string>
+    <string name="mod_config_gyro_horizontal_speed" formatted="false">水平速度 (%)</string>
+    <string name="mod_config_gyro_vertical_speed" formatted="false">垂直速度 (%)</string>
+    <string name="mod_config_gyro_small_movement_filter">微小移动过滤（0 = 关闭）</string>
+    <string name="mod_config_gyro_sensitivity_x" formatted="false">水平灵敏度 (%)</string>
+    <string name="mod_config_gyro_sensitivity_y" formatted="false">垂直灵敏度 (%)</string>
+    <string name="mod_config_gyro_invert_x">反转水平轴</string>
+    <string name="mod_config_gyro_invert_y">反转垂直轴</string>
+    <string name="mod_config_gyro_deadzone">死区</string>
     <string name="mod_config_press_any_key">按任意键完成绑定...</string>
     <string name="mod_config_key_unknown">未知</string>
     <string name="mod_config_color_alpha_short">A</string>
@@ -594,6 +825,8 @@
     <string name="mod_config_color_green_short">G</string>
     <string name="mod_config_color_blue_short">B</string>
     <string name="mod_config_color_hex_hint" formatted="false">#AARRGGBB</string>
+    <string name="hud_editor_drag_hint">拖动以移动面板</string>
+    <string name="hud_editor_drag_description">HUD 编辑器。拖动此区域可移动面板。</string>
 
     <!-- Options Editor -->
     <string name="edit_options">编辑选项</string>
@@ -673,92 +906,13 @@
     <string name="curseforge_download_failed">下载失败</string>
     <string name="curseforge_available_files">可用文件</string>
 
-    <!-- Missing translations -->
-    <string name="beta_badge">Beta</string>
-    <string name="debug_badge">Debug</string>
-    <string name="cursor">光标</string>
-    <string name="bedrock_edition">基岩版</string>
-    <string name="current_instance">当前实例</string>
-    <string name="content_mgmt_section_title">内容管理</string>
-    <string name="misc_section_title">其他</string>
-    <string name="view_all">查看全部 →</string>
-    <string name="import_so_plugin_title">导入 SO 插件</string>
-    <string name="plugin_name_label">插件名称</string>
-    <string name="plugin_type_label">类型</string>
-    <string name="plugin_version_label">版本</string>
-    <string name="import_button">导入</string>
-    <string name="settings_subtitle">配置常用启动器选项</string>
-    <string name="settings_tab_basic">基础设置</string>
-    <string name="settings_tab_personalize">个性化</string>
-    <string name="settings_tab_updates">更新</string>
-    <string name="settings_tab_about">关于</string>
-    <string name="settings_tab_migration">迁移</string>
-    <string name="settings_theme_desc">选择应用主题</string>
-    <string name="launch_vertically">竖屏启动</string>
-    <string name="launch_vertically_desc">强制游戏以竖屏模式启动</string>
-    <string name="instance_settings_title">实例设置</string>
-    <string name="instance_tab_general">常规</string>
-    <string name="instance_tab_launch_options">启动选项</string>
-    <string name="instance_tab_management">管理</string>
-    <string name="instance_new_name">新名称</string>
-    <string name="instance_rename_hint">仅重命名文件夹。游戏版本和类型不受影响。</string>
-    <string name="instance_custom_icon">自定义图标（需为正方形）</string>
-    <string name="instance_clear_icon">清除</string>
-    <string name="instance_icon_hint">将保存为版本文件夹下的 LargeLogo.png。点击图标进行更改。</string>
-    <string name="instance_isolation_desc">为此实例隔离游戏数据。其他实例不会受到影响。</string>
-    <string name="instance_danger_zone">危险区域</string>
-    <string name="instance_danger_zone_desc">这些操作会影响实例注册信息或本地文件。继续前请仔细确认。</string>
-    <string name="instance_delete_desc">从设备中永久删除此实例，包括世界、配置和已安装内容。</string>
-    <string name="instance_delete_warning">此操作无法撤销。</string>
-    <string name="instance_delete_confirm_title">删除实例</string>
-    <string name="instance_delete_confirm_msg">确定要删除此实例吗？包括世界在内的所有数据都将被永久移除。</string>
-    <string name="instance_backup_title">备份实例</string>
-    <string name="instance_backup_desc">将此实例完整备份到 Download/LeviLauncher/Backups。</string>
-    <string name="instance_backup_button">备份实例</string>
-    <string name="instance_backup_confirm_message">现在创建此实例的完整备份吗？如果 Minecraft 正在运行，建议先退出游戏，避免备份过程中数据变化。</string>
-    <string name="instance_backup_in_progress">正在备份实例…</string>
-    <string name="instance_backup_success_title">备份已创建</string>
-    <string name="instance_backup_success_message">备份已保存到：\n%1$s</string>
-    <string name="instance_backup_failed_title">备份失败</string>
-    <string name="instance_backup_failed_message">无法创建备份：\n%1$s</string>
-    <string name="instance_import_backup_button">导入备份</string>
-    <string name="instance_batch_backup_button">批量备份</string>
-    <string name="instance_batch_backup_title">批量备份实例</string>
-    <string name="instance_batch_backup_select_message">选择需要备份的实例。如果 Minecraft 正在运行，建议先退出游戏，避免备份过程中数据变化。</string>
-    <string name="instance_batch_backup_select_all">选择全部实例</string>
-    <string name="instance_batch_backup_no_instances">当前没有可备份的实例。</string>
-    <string name="instance_batch_backup_no_selection">请至少选择一个实例。</string>
-    <string name="instance_batch_backup_in_progress">正在备份 %1$s（%2$d/%3$d）…</string>
-    <string name="instance_batch_backup_success_title">备份已创建</string>
-    <string name="instance_batch_backup_success_message">已创建 %1$d 个备份：\n%2$s</string>
-    <string name="instance_batch_backup_partial_title">部分备份完成</string>
-    <string name="instance_batch_backup_partial_message">已创建 %1$d 个备份，%2$d 个失败。\n\n已保存：\n%3$s\n\n失败：\n%4$s</string>
-    <string name="instance_batch_backup_failed_title">批量备份失败</string>
-    <string name="instance_batch_backup_failed_message">未能创建任何备份：\n%1$s</string>
-    <string name="instance_restore_title">恢复备份</string>
-    <string name="instance_restore_in_progress">正在恢复实例备份…</string>
-    <string name="instance_restore_success_title">恢复完成</string>
-    <string name="instance_restore_success_message">已恢复：%1$s</string>
-    <string name="instance_restore_failed_title">恢复失败</string>
-    <string name="instance_restore_failed_message">无法恢复备份：\n%1$s</string>
-    <string name="skin_packs_title">皮肤包</string>
-    <string name="worlds_category">世界</string>
-    <string name="resource_packs_category">资源包</string>
-    <string name="behavior_packs_category">行为包</string>
-    <string name="skin_packs_category">皮肤包</string>
-    <string name="screenshots_category">截图</string>
-    <string name="servers_category">服务器</string>
-    <string name="saved_to_gallery">已保存到相册</string>
-    <string name="inbuilt_mod_virtual_cursor">虚拟光标</string>
-    <string name="inbuilt_mod_virtual_cursor_desc">使用虚拟触控板控制鼠标</string>
-    <string name="virtual_cursor_enabled">光标已启用</string>
-    <string name="virtual_cursor_disabled">光标已禁用</string>
-    <string name="cursor_sensitivity_label">光标灵敏度：</string>
+    <!-- Navigation Bar -->
     <string name="nav_launch">启动</string>
     <string name="nav_import">导入</string>
     <string name="nav_instances">实例</string>
     <string name="nav_about">关于</string>
     <string name="nav_settings">设置</string>
+
     <string name="search_instances_hint">搜索…</string>
     <string name="instances_label">实例</string>
     <string name="select_instance_title">选择实例</string>
@@ -768,6 +922,7 @@
     <string name="tag_installed">已安装</string>
     <string name="tag_custom">自定义</string>
     <string name="vanilla_prefix">原版 %s</string>
+
     <string name="about_page_title">关于</string>
     <string name="about_subtitle">LeviLauncher — 现代 Minecraft 基岩版启动器</string>
     <string name="about_authors_title">👥 作者与维护者</string>
@@ -784,6 +939,7 @@
     <string name="about_contribute_desc">欢迎通过 Issues 或 Pull Requests 改进 LeviLauncher。</string>
     <string name="about_issues">Issue</string>
     <string name="about_star_fork">Star / Fork</string>
+
     <string-array name="launcher_tips">
         <item>在设置中可以调整主题、颜色、背景和其他外观选项，让启动器更符合你的使用习惯。</item>
         <item>LeviLauncher 是开源项目。你可以通过 GitHub Issues 反馈启动器问题或提出改进建议。</item>
@@ -797,6 +953,7 @@
         <item>CurseForge 可以让你直接浏览并下载社区内容。</item>
         <item>导入模组以扩展或增强 Minecraft 功能和性能。</item>
     </string-array>
+    <!-- Personalization -->
     <string name="theme_color_title">主题颜色</string>
     <string name="theme_color_desc">应用的主强调色</string>
     <string name="preset_colors">预设颜色</string>
@@ -814,57 +971,8 @@
 
     <string name="unsupported_version_title">不支持的版本</string>
     <string name="unsupported_version_msg">此启动器不支持早于 1.21.80 的 Minecraft 版本。</string>
-    <!-- Completed localization coverage -->
-    <string name="delete_account_title">删除账户</string>
-    <string name="delete_account_confirm">确定要删除此账户吗？</string>
-    <string name="ms_login_header_subtitle">安全登录 Minecraft</string>
-    <string name="ms_login_retrying">连接中断。正在安全重试…</string>
-    <string name="ms_choose_login_method">登录 Minecraft</string>
-    <string name="ms_choose_login_method_desc">选择基于浏览器的设备代码流程，或继续使用内嵌 Microsoft 页面。</string>
-    <string name="ms_device_code_login">使用浏览器继续</string>
-    <string name="ms_device_code_option_title">设备代码（推荐）</string>
-    <string name="ms_device_code_login_desc">打开一个已自动填入设备代码的私密浏览器会话。</string>
-    <string name="ms_webview_login">打开内嵌登录</string>
-    <string name="ms_webview_option_title">内嵌 WebView</string>
-    <string name="ms_webview_login_desc">无需离开 LeviLauncher 即可登录。当浏览器流程不可用时使用此方式。</string>
-    <string name="ms_device_code_title">使用设备代码登录</string>
-    <string name="ms_device_code_instructions">打开 Microsoft 设备登录页面，输入此代码，然后批准访问。LeviLauncher 会自动完成后续操作。</string>
-    <string name="ms_device_code_label">Microsoft 设备代码</string>
-    <string name="ms_device_code_requesting">正在请求安全代码…</string>
-    <string name="ms_device_code_waiting_code">--------</string>
-    <string name="ms_device_code_waiting">正在等待你在浏览器中完成操作…</string>
-    <string name="ms_device_code_checking">正在检查 Microsoft 登录结果…</string>
-    <string name="ms_device_code_reconnecting">连接已变化。正在自动重试…</string>
-    <string name="ms_device_code_authorized">Microsoft 已批准登录。正在完成…</string>
-    <string name="ms_device_code_browser_opened">请在浏览器中完成新的 Microsoft 登录，然后返回此处。</string>
-    <string name="ms_device_code_expires">代码将在 %1$d:%2$02d 后过期</string>
-    <string name="ms_device_code_copy">复制代码</string>
-    <string name="ms_device_code_copied">代码已复制</string>
-    <string name="ms_device_code_open_browser">打开 Microsoft 登录</string>
-    <string name="ms_device_code_step_title">在浏览器中完成登录</string>
-    <string name="ms_device_code_browser_note">LeviLauncher 会在私密会话中打开默认浏览器，自动填写代码，并请求一次新的 Microsoft 登录。</string>
-    <string name="ms_choose_other_method">其他方式</string>
-    <string name="ms_no_browser">此设备上没有可用的浏览器。</string>
-    <string name="ms_default_browser_no_private_mode">默认浏览器不支持私密登录。请更新浏览器或使用 WebView 登录。</string>
-    <string name="ms_login_ssl_failed">无法验证安全的 Microsoft 登录页面。</string>
-    <string name="ms_login_state_failed">无法验证 Microsoft 登录响应。请重新开始登录。</string>
-    <string name="ms_login_missing_code">Microsoft 未返回登录代码。请重新开始登录或使用设备代码登录。</string>
-    <string name="ms_feature_disabled_title">功能已禁用</string>
-    <string name="ms_feature_disabled_desc">请在设置中启用“使用 LeviLauncher 登录 Minecraft”，以管理 Microsoft 账户。</string>
-    <string name="ms_activated">已激活</string>
-    <string name="inbuilt_mod_gyro">陀螺仪</string>
-    <string name="inbuilt_mod_gyro_desc">使用设备陀螺仪控制摄像机旋转</string>
-    <string name="inbuilt_mod_pojav_controls">Pojav 控制</string>
-    <string name="inbuilt_mod_pojav_controls_desc">用完全可自定义的 Pojav 风格控制替换 Minecraft 触摸控制</string>
-    <string name="inbuilt_mod_more_buttons">更多按钮</string>
-    <string name="inbuilt_mod_more_buttons_desc">使用单键映射和 SVG 图标创建自定义屏幕按钮</string>
-    <string name="mod_config_overlay_show_everywhere" formatted="false">始终显示</string>
-    <string name="mod_config_zoom_transition">过渡时长 (ms)</string>
-    <string name="mod_config_gyro_sensitivity_x" formatted="false">水平灵敏度 (%)</string>
-    <string name="mod_config_gyro_sensitivity_y" formatted="false">垂直灵敏度 (%)</string>
-    <string name="mod_config_gyro_invert_x">反转水平轴</string>
-    <string name="mod_config_gyro_invert_y">反转垂直轴</string>
-    <string name="mod_config_gyro_deadzone">死区</string>
+
+    <!-- Generic UI strings added during localization cleanup -->
     <string name="close">关闭</string>
     <string name="previous">上一步</string>
     <string name="next">下一步</string>
@@ -914,6 +1022,8 @@
     <string name="custom_color_hint">#RRGGBB 或 R,G,B</string>
     <string name="screenshot_name_placeholder">截图名称</string>
     <string name="screenshot_date_placeholder">日期：2024-01-01 12:00:00</string>
+
+    <!-- More Buttons editor -->
     <string name="more_buttons_intro">创建 Minecraft 风格的屏幕按钮，每个按钮仅映射到一个键盘按键。按钮不会执行宏、按键序列、自动重复或自动点击。</string>
     <string name="more_buttons_add_button">添加按钮</string>
     <string name="more_buttons_limit_reached">已达到最多 %1$d 个自定义按钮的限制。</string>
@@ -971,99 +1081,17 @@
     <string name="more_buttons_no_svg_selected">未选择 SVG</string>
     <string name="more_buttons_default_name">按钮</string>
 
+
     <!-- Hotbar Slot -->
     <string name="inbuilt_mod_hotbar_slot">快捷栏槽位</string>
     <string name="inbuilt_mod_hotbar_slot_desc">添加独立的 1–9 按钮，用于选择快捷栏槽位</string>
     <string name="hotbar_slot_content_description">快捷栏槽位 %1$d</string>
-
-
-    <!-- Added translations for strings present in the current English resources -->
-    <string name="instance_shortcut_title">主屏幕快捷方式</string>
-    <string name="instance_shortcut_desc">名称和图标的更改会自动保存。点击“添加快捷方式”以创建或更新主屏幕快捷方式。</string>
-    <string name="instance_shortcut_name">快捷方式名称</string>
-    <string name="instance_shortcut_icon">快捷方式图标</string>
-    <string name="instance_shortcut_choose_icon">选择图标</string>
-    <string name="instance_shortcut_default_icon">使用默认图标</string>
-    <string name="instance_shortcut_add_button">添加快捷方式</string>
-    <string name="instance_settings_auto_save_failed">无法保存此实例设置。</string>
-    <string name="instance_shortcut_not_supported">您的主屏幕启动器不支持固定快捷方式。</string>
-    <string name="instance_shortcut_missing">此 Minecraft 实例已不可用。</string>
-    <string name="custom_flat_world_subtitle">使用自定义生物群系和方块层创建世界</string>
-    <string name="world_settings">世界设置</string>
-    <string name="world_settings_hint">选择新世界的基本设置</string>
-    <string name="layers_title">层</string>
-    <string name="add_layer_compact">添加层</string>
-    <string name="no_layers_title">还没有层</string>
-    <string name="no_layers_hint">至少添加一层方块才能创建世界</string>
-    <string name="reorder_layer">重新排序此层</string>
-    <string name="delete_layer">删除此层</string>
-    <string name="block_id_hint">minecraft:stone</string>
-    <string name="scan_downloads">扫描</string>
-    <string name="scan_downloads_scanning">正在扫描…</string>
-    <string name="scan_downloads_none_found">下载文件夹中未找到 .levipack 或 .so 模组</string>
-    <string name="scan_downloads_failed">无法扫描下载文件夹</string>
-    <string name="scan_downloads_permission_denied">扫描下载文件夹需要存储访问权限</string>
-    <string name="scan_downloads_results_title">下载文件夹中的模组</string>
-    <string name="scan_downloads_results_subtitle">选择要添加的模组。扫描仅检查主下载文件夹。</string>
-    <string name="scan_downloads_add">添加</string>
-    <string name="scan_downloads_adding">正在添加…</string>
-    <string name="scan_downloads_added">已添加</string>
-    <string name="scan_downloads_added_message">已添加 %1$s</string>
-    <string name="scan_downloads_levipack">LeviPack</string>
-    <string name="scan_downloads_native_library">原生库</string>
-    <string name="scan_downloads_file_details">%1$s • %2$s</string>
-    <string name="external_mods">外部模组</string>
-    <string name="external_mods_subtitle">适用于 Minecraft %1$s 的社区模组</string>
-    <string name="external_mods_no_version">安装模组前请选择 Minecraft 版本</string>
-    <string name="external_mods_search_hint">搜索模组、作者或版本…</string>
-    <string name="external_mods_compatible_only">仅显示兼容项</string>
-    <string name="external_mods_all_versions">所有 Minecraft 版本</string>
-    <string name="external_mods_sort_newest">最新</string>
-    <string name="external_mods_sort_name">名称 A–Z</string>
-    <string name="external_mods_empty">没有符合这些筛选条件的模组</string>
-    <string name="external_mods_load_failed">无法刷新目录。正在显示已保存的副本。</string>
-    <string name="external_mods_refresh">刷新目录</string>
-    <string name="external_mods_refreshed">目录已刷新</string>
-    <string name="external_mods_join_discord">加入社区 Discord</string>
-    <string name="external_mods_discord_open_failed">没有应用可以打开 Discord 邀请</string>
-    <string name="external_mods_download">正在下载 %1$s</string>
-    <string name="external_mods_importing">正在导入模组…</string>
-    <string name="external_mods_installed">已安装 %1$s</string>
-    <string name="external_mods_install_failed">无法安装 %1$s：%2$s</string>
-    <string name="external_mods_open_failed">没有浏览器可以打开此下载</string>
-    <string name="external_mods_direct_download">直接下载</string>
-    <string name="external_mods_ad_download">广告下载</string>
-    <string name="external_mods_external_link">外部链接</string>
-    <string name="external_mods_open_link">打开链接</string>
-    <string name="external_mods_external_dialog_title">外部下载</string>
-    <string name="external_mods_ad_dialog_title">广告支持的下载</string>
-    <string name="external_mods_external_dialog_message">%1$s 使用 LeviLauncher 之外的下载页面。\n\n1. 点击“打开链接”并下载 .levipack 或 .so 文件。\n2. 返回 LeviLauncher 并打开“模组”。\n3. 点击“扫描”。\n4. 点击要导入的模组旁边的“添加”。\n\n扫描仅检查主下载文件夹。如果浏览器将文件保存到了其他位置，请将文件移动到该文件夹。</string>
-    <string name="external_mods_ad_dialog_message">%1$s 使用由其开发者选择的广告支持下载页面。LeviLauncher 不控制该页面或其中的广告。\n\n1. 点击“打开链接”并下载 .levipack 或 .so 文件。\n2. 返回 LeviLauncher 并打开“模组”。\n3. 点击“扫描”。\n4. 点击要导入的模组旁边的“添加”。\n\n扫描仅检查主下载文件夹。只下载模组文件；不要安装无关应用，也不要允许通知。</string>
-    <string name="external_mods_by_author">作者：%1$s</string>
-    <string name="external_mods_version">模组 %1$s</string>
-    <string name="external_mods_minecraft_versions">Minecraft %1$s</string>
-    <string name="external_mods_update">更新</string>
-    <string name="external_mods_installed_button">已安装</string>
-    <string name="external_mods_incompatible">不兼容</string>
-    <string name="foreground_service">前台服务</string>
-    <string name="foreground_service_desc">切换应用时阻止 Bedrock 暂停当前会话，并保持进程、CPU 和 Wi-Fi 活跃，从而让 Minecraft 继续运行。</string>
-    <string name="foreground_service_warning">注意：可能会让手机更快发热并增加电池消耗。</string>
-    <string name="foreground_service_channel">Minecraft 后台保护</string>
-    <string name="foreground_service_notification_title">正在保持 Minecraft 活跃</string>
-    <string name="foreground_service_notification_text">Minecraft 后台模式已启用。当前会话会持续保持 CPU 和网络访问可用。</string>
-    <string name="mod_menu_compact">紧凑模组菜单</string>
-    <string name="mod_menu_compact_desc">使用更小的菜单、密集的模块列表和紧凑的筛选器</string>
-    <string name="mod_config_gyro_sensitivity_multiplier" formatted="false">灵敏度倍数（100% = 1x）</string>
-    <string name="mod_config_gyro_horizontal_speed" formatted="false">水平速度 (%)</string>
-    <string name="mod_config_gyro_vertical_speed" formatted="false">垂直速度 (%)</string>
-    <string name="mod_config_gyro_small_movement_filter">微小移动过滤（0 = 关闭）</string>
-    <string name="hud_editor_drag_hint">拖动以移动面板</string>
-    <string name="hud_editor_drag_description">HUD 编辑器。拖动此区域可移动面板。</string>
     <string name="mod_config_hotbar_item_icons">使用快捷栏中的物品图标</string>
     <string name="mod_config_hotbar_item_counts">显示物品数量</string>
     <string name="mod_config_hotbar_slot_enabled">显示快捷栏槽位 %1$d</string>
     <string name="mod_config_hotbar_slot_size">快捷栏槽位 %1$d 大小 (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">快捷栏槽位 %1$d 不透明度</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">新增内容</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">继续</string>
@@ -1086,6 +1114,7 @@
     <string name="mod_config_category_button">按钮</string>
     <string name="mod_config_visible_slots">可见槽位</string>
     <string name="mod_config_hotbar_slot_section">快捷栏槽位 %1$d</string>
+    <!-- Selection & Batch Operations -->
     <string name="select">选择</string>
     <string name="select_all">全选</string>
     <string name="selected">已选择</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -452,7 +452,7 @@
     <string name="genuine_badge_label">未通过正版验证</string>
     <string name="invalid_license_detected_toast">非正版MC，请确保设备上MC来自于谷歌商店</string>
 
-    <string name="full_mods_title">模组</string>
+    <string name="full_mods_title">模组 </string>
     <string name="total_mods">模组总数：</string>
     <string name="enabled_mods">已启用：</string>
     <string name="add_mod">添加模组</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
+<!-- NOTE: Keep this file aligned with the English default (values/strings.xml):
+     same resource keys and order, comments, sections, XML structure, and formatting
+     (including indentation, spaces, and blank lines).
+
+     Translations must remain grammatically and linguistically correct for the target
+     language. Locale-specific plural forms may differ when required by the language.
+     Do not change placeholders or resource attributes. -->
+
 <resources>
     <!-- Common -->
     <string name="app_name">LeviLauncher</string>
@@ -108,7 +116,7 @@
     <string name="unknown_sources_permission_message">To install or update this app, please grant permission to install unknown apps. Click "Grant" to open system settings, enable the permission for this app, and return to continue.</string>
 
     <string name="check_update">Check for updates</string>
-    <string name="version_prefix">Version: </string>
+    <string name="version_prefix">Version:</string>
     <string name="unknown_error">Unknown error</string>
     <string name="preloader_sigs_title">Runtime Data</string>
     <string name="preloader_sigs_last_update">Last update: %1$s</string>
@@ -162,7 +170,7 @@
     <string name="repair_preparing">Preparing…</string>
     <string name="repair_processing">Extracting libraries…</string>
     <string name="repair_finalizing">Finalizing repair…</string>
-
+    <!-- Storage Migration -->
     <string name="storage_migration_title">Storage Migration Required</string>
     <string name="storage_migration_message">LeviLauncher must migrate data from games/org.levimc to %1$s before continuing.
 
@@ -207,21 +215,21 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="shared_storage_layout_mode_legacy">Original internal/external directories</string>
     <string name="shared_storage_layout_status">Current mode: %1$s\nInternal: %2$s\nExternal: %3$s</string>
     <string name="shared_storage_layout_changed">Storage directory selection updated. Restart Minecraft and reopen content management for the change to fully apply.</string>
-
+    <!-- Theme -->
     <string name="theme_title">Theme Mode</string>
     <string name="theme_follow_system">Follow System</string>
     <string name="theme_light">Light Mode</string>
     <string name="theme_dark">Dark Mode</string>
 
     <string name="error_no_browser">No browser available</string>
-
+    <!-- License & Security -->
     <string name="eula_title">LeviLauncher License Agreement</string>
     <string name="eula_message"><b>Welcome to LeviLauncher</b>\n\nBy using this software you agree to:\n\n• This is an <b>unofficial</b> Minecraft launcher\n• You must own a <b>licensed</b> copy of Minecraft\n• Any form of piracy or cheating is prohibited\n• Mods/resource packs are used at your own risk\n• Not affiliated with Mojang/Microsoft\n\nContinued use constitutes agreement</string>
     <string name="eula_agree">Accept</string>
     <string name="eula_exit">Decline</string>
 
     <string name="allow_unknown_sources">Please allow installation from unknown sources before proceeding</string>
-
+    <!-- Version Management -->
     <string name="dialog_title_delete_version">Delete Version</string>
     <string name="dialog_message_delete_version">Are you sure to delete this custom version? This action cannot be undone.</string>
     <string name="dialog_positive_delete">Delete</string>
@@ -241,7 +249,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="version_isolation">Version Isolation</string>
     <string name="launch_vertically">Launch Vertically</string>
     <string name="launch_vertically_desc">Force the game to launch in portrait mode</string>
-
+    <!-- Instance Management -->
     <string name="instance_settings_title">Instance Settings</string>
     <string name="instance_tab_general">General</string>
     <string name="instance_tab_launch_options">Launch Options</string>
@@ -444,7 +452,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="genuine_badge_label">License not verified</string>
     <string name="invalid_license_detected_toast">Non-genuine Minecraft detected. Ensure Minecraft is from Google Play Store</string>
 
-    <string name="full_mods_title">Mods </string>
+    <string name="full_mods_title">Mods</string>
     <string name="total_mods">Total Mods:</string>
     <string name="enabled_mods">Enabled:</string>
     <string name="add_mod">Add Mod</string>
@@ -542,7 +550,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="mod_config_error_maximum">%1$s must be at most %2$s</string>
     <string name="mod_config_error_boolean">%1$s must be on or off</string>
     <string name="mod_config_error_string">%1$s must be text</string>
-
+    <!-- Mod Configuration -->
     <plurals name="mod_config_files_count">
         <item quantity="one">%d editable config</item>
         <item quantity="other">%d editable configs</item>
@@ -643,7 +651,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <!-- Popup labels -->
     <string name="label_current_account">Current Account</string>
     <string name="label_other_accounts">Other Accounts</string>
-
+    <!-- Crash & Diagnostics -->
     <string name="crash_title">Application crashed</string>
     <string name="crash_upload">Crash report upload</string>
     <string name="crash_details_title">Crash details</string>
@@ -933,7 +941,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="about_star_fork">Star / Fork</string>
 
     <string-array name="launcher_tips">
-       <item>Settings lets you adjust theme, color, background, and other appearance options to match your setup.</item>
+        <item>Settings lets you adjust theme, color, background, and other appearance options to match your setup.</item>
         <item>LeviLauncher is open source. Use GitHub issues to report launcher problems or suggest improvements.</item>
         <item>Use the version dropdown to switch the current instance quickly.</item>
         <item>Do people actually read these?</item>
@@ -945,7 +953,7 @@ Migration must complete before LeviLauncher can continue.</string>
         <item>CurseForge lets you browse and download community content directly.</item>
         <item>Import mods to extend or enhance Minecraft features and performance.</item>
     </string-array>
-
+    <!-- Personalization -->
     <string name="theme_color_title">Theme Color</string>
     <string name="theme_color_desc">The primary accent color of the application</string>
     <string name="preset_colors">PRESET COLORS</string>
@@ -1083,6 +1091,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="mod_config_hotbar_slot_enabled">Show hotbar slot %1$d</string>
     <string name="mod_config_hotbar_slot_size">Hotbar slot %1$d size (dp)</string>
     <string name="mod_config_hotbar_slot_opacity">Hotbar slot %1$d opacity</string>
+    <!-- Changelog & News -->
     <string name="changelog_title">What’s new</string>
     <string name="changelog_version">LeviLauncher %1$s</string>
     <string name="changelog_continue">Continue</string>
@@ -1105,7 +1114,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="mod_config_category_button">Button</string>
     <string name="mod_config_visible_slots">Visible Slots</string>
     <string name="mod_config_hotbar_slot_section">Hotbar Slot %1$d</string>
-
+    <!-- Selection & Batch Operations -->
     <string name="select">Select</string>
     <string name="select_all">Select All</string>
     <string name="selected">Selected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="unknown_sources_permission_message">To install or update this app, please grant permission to install unknown apps. Click "Grant" to open system settings, enable the permission for this app, and return to continue.</string>
 
     <string name="check_update">Check for updates</string>
-    <string name="version_prefix">Version:</string>
+    <string name="version_prefix">Version: </string>
     <string name="unknown_error">Unknown error</string>
     <string name="preloader_sigs_title">Runtime Data</string>
     <string name="preloader_sigs_last_update">Last update: %1$s</string>
@@ -452,7 +452,7 @@ Migration must complete before LeviLauncher can continue.</string>
     <string name="genuine_badge_label">License not verified</string>
     <string name="invalid_license_detected_toast">Non-genuine Minecraft detected. Ensure Minecraft is from Google Play Store</string>
 
-    <string name="full_mods_title">Mods</string>
+    <string name="full_mods_title">Mods </string>
     <string name="total_mods">Total Mods:</string>
     <string name="enabled_mods">Enabled:</string>
     <string name="add_mod">Add Mod</string>


### PR DESCRIPTION
This PR aligns all locale `strings.xml` files to the English reference format, ensuring every file follows the same structure, comments, and string key ordering.

## Changes made

### Alignment & Structure
- [x] Added header comment to all 11 `strings.xml` files instructing translators to keep line numbers, comments, and string keys aligned with `values/strings.xml`
- [x] Unified header comment text across all files (English had different wording than the 10 locale files)
- [x] Synced comment placement, key order, and `formatted="false"` attributes across all files
- [x] All 10 non-Russian locales now have identical line count (1144 lines) with perfect line-by-line key alignment

### Missing Translations
- [x] Added missing `flat_layers_count` plurals in all 10 locale files (`es`, `fr`, `hi`, `idn`, `ja`, `pt`, `ru`, `tr`, `vi`, `zh-rCN`)

## Highlights

> [!IMPORTANT]
>
> * All 11 files verified: valid XML, 989 keys in every file, 38 comments matching verbatim
> * Russian uses 4 plural forms for `flat_layers_count`, causing a +2 line divergence from English — this is intentional and linguistically correct
> * Every locale file now mirrors the English reference: same comment on the same line, same key on the same line

<details>
<summary><strong>File-by-file summary</strong></summary>

| File | Lines | Keys | Status |
| --- | --- | --- | --- |
| `values/strings.xml` (English) | 1144 | 989 | Reference |
| `values-es/strings.xml` | 1144 | 989 | Aligned |
| `values-fr/strings.xml` | 1144 | 989 | Aligned |
| `values-hi/strings.xml` | 1144 | 989 | Aligned |
| `values-idn/strings.xml` | 1144 | 989 | Aligned |
| `values-ja/strings.xml` | 1144 | 989 | Aligned |
| `values-pt/strings.xml` | 1144 | 989 | Aligned |
| `values-ru/strings.xml` | 1146 | 989 | +2 lines (4-form plurals) |
| `values-tr/strings.xml` | 1144 | 989 | Aligned |
| `values-vi/strings.xml` | 1144 | 989 | Aligned |
| `values-zh-rCN/strings.xml` | 1144 | 989 | Aligned |

</details>